### PR TITLE
Create connection pool with support for multiple protocols, security levels, and alt-svc/prior knowledge

### DIFF
--- a/hyper/compat.py
+++ b/hyper/compat.py
@@ -18,6 +18,9 @@ is_py2 = (_ver[0] == 2)
 is_py3 = (_ver[0] == 3)
 
 if is_py2:
+    from httplib import HTTPConnection as _HTTPConnection
+    class HTTPConnection(_HTTPConnection, object): # convert to new-style class
+        pass
     from urlparse import urlparse
 
     def to_byte(char):
@@ -32,6 +35,7 @@ if is_py2:
         return zlib.compressobj(level, method, wbits, memlevel, strategy)
 
 elif is_py3:
+    from http.client import HTTPConnection
     from urllib.parse import urlparse
 
     def to_byte(char):

--- a/hyper/http20/tls.py
+++ b/hyper/http20/tls.py
@@ -29,7 +29,7 @@ cert_loc = path.join(path.dirname(__file__), '..', 'certs.pem')
 
 
 if is_py3: # pragma: no cover
-    def wrap_socket(socket, server_hostname):
+    def wrap_socket(socket, server_hostname=None):
         """
         A vastly simplified SSL wrapping function. We'll probably extend this to
         do more things later.
@@ -42,11 +42,9 @@ if is_py3: # pragma: no cover
         if ssl.HAS_SNI:
             return _context.wrap_socket(socket, server_hostname=server_hostname)
 
-        wrapped = _context.wrap_socket(socket)  # pragma: no cover
-        assert wrapped.selected_npn_protocol() == 'HTTP-draft-09/2.0'
-        return wrapped
+        return _context.wrap_socket(socket)  # pragma: no cover
 else: # pragma: no cover
-    def wrap_socket(socket, server_hostname):
+    def wrap_socket(socket, server_hostname=None):
         return ssl.wrap_socket(socket, ssl_version=ssl.PROTOCOL_SSLv23,
             ca_certs=cert_loc, cert_reqs=_verify_mode)
 

--- a/hyper/pool.py
+++ b/hyper/pool.py
@@ -1,0 +1,244 @@
+# -*- coding: utf-8 -*-
+"""
+hyper/pool
+~~~~~~~~~~~~~
+
+FIXME
+"""
+import itertools
+import socket
+import time
+
+from .compat import urlparse, HTTPConnection
+from .http20.connection import HTTP20Connection
+from .http20.tls import wrap_socket
+
+
+class SocketFactory(object):
+    def __init__(self, timeout=5):
+        self.timeout = timeout
+
+    def __call__(self, host, port):
+        return socket.create_connection((host, port), self.timeout)
+
+
+class UpgradedConnection(Exception):
+    def __init__(self, conn):
+        super(UpgradedConnection, self).__init__(conn)
+        self.conn = conn
+
+
+# TODO include list of protocols the server *does* support, for debugging
+class UnsupportedMinProtocol(Exception):
+    pass
+
+
+# TODO better name
+class Tracker(object):
+    def __init__(self, pool, host, port, security, protocol):
+        self.pool = pool
+        self.host = host
+        self.port = port
+        self.security = security
+        self.protocol = protocol
+
+    def switch_protocol(self, new_protocol):
+        self.pool.switch_protocol(self.conn, self.host, self.port, self.security, self.protocol, new_protocol)
+        self.protocol = new_protocol
+
+    def relinquish(self):
+        self.pool.relinquish(self.conn, self.host, self.port, self.security, self.protocol)
+
+
+class HTTP11Protocol(HTTPConnection):
+    def __init__(self, sock, host, port, tracker):
+        super(HTTP11Protocol, self).__init__(host, port)
+        self.sock = sock
+        self.tracker = tracker
+
+    def connect(self):
+        # we're already connected; this is basically a no-op
+        if self._tunnel_host:
+            self._tunnel()
+
+    def putrequest(self, method, url, skip_host=False,
+                   skip_accept_encoding=False, skip_upgrade=False):
+        super(HTTP11Protocol, self).putrequest(method, url, skip_host=skip_host,
+                                               skip_accept_encoding=skip_accept_encoding)
+        self.putheader('Connection', 'Upgrade, HTTP2-Settings')
+        # TODO should include draft number, e.g. h2-10
+        self.putheader('Upgrade', 'h2')
+        #self.putheader('HTTP2-Settings', ) # FIXME
+
+    def getresponse(self, buffering=False):
+        response = super(HTTP11Protocol, self).getresponse(buffering=buffering)
+        if response.status == 101 and response.getheader('Connection') == 'Upgrade' and response.getheader('Upgrade') == 'h2':
+            # TODO are all response headers consumed at this point?
+            self.tracker.switch_protocol('h2')
+            raise UpgradedConnection(HTTP20Protocol(self.sock, self.host, self.port, self.tracker))
+        self.tracker.relinquish()
+        return response
+
+
+class HTTP20Protocol(HTTP20Connection):
+    def __init__(self, sock, host, port, tracker):
+        super(HTTP20Protocol, self).__init__(host, port)
+        self._sock = sock
+        self.tracker = tracker
+
+
+def weak_security(sock, host, port, protocols):
+    # TODO use protocols, raise UnsupportedMinProtocol if server and client have none in common
+    ssl_sock = wrap_socket(sock)
+    return ssl_sock, ssl_sock.selected_npn_protocols()
+
+# TODO maybe some kind of (sock, host, port) association class? at least use (host, port) address pairs
+def strong_security(sock, host, port, protocols):
+    # TODO use protocols
+    ssl_sock = wrap_socket(sock, host)
+    return ssl_sock, ssl_sock.selected_npn_protocols()
+
+
+# TODO have different hostnames that point to the same IP share a connection, unless user specifies otherwise
+# - but tolerate different IPs for same hostname, since it could be GeoIP or DNS-based load balancing/failover
+class SmartPool(object):
+    def __init__(self, socket_factory=None):
+        self._socket_factory = socket_factory or SocketFactory()
+        self._registered_securities = []
+        self._registered_protocols = []
+        self._connections = {}
+        self._known_services = {}
+
+    def get(self, host, port, min_security, min_protocol):
+        # Look for an existing connection that meets the security and protocol
+        # conditions.
+        # TODO construct a dict mapping securities/protocols to precedence integers, to simplify logic
+        for security_name, security_factory, upgrade in reversed(self._registered_securities):
+            for protocol_name, protocol_factory, single_conn in reversed(self._registered_protocols):
+                # TODO reuse existing one with completed state
+                socks = self._connections.get((host, port, security_name, protocol_name), [])
+                if len(socks) > 0:
+                    sock = socks[-1]
+
+                    connected = True
+                    try:
+                        sock.sock.getpeername() # TODO more elegant way
+                    except socket.error as e:
+                        if e.errno != errno.ENOTCONN:
+                            # It's an error other than the one we expected if
+                            # we're not connected.
+                            raise
+                        connected = False
+
+                    if not single_conn or not connected:
+                        socks.pop()
+                    return sock, security_name, protocol_name
+
+                if protocol_name == min_protocol:
+                    break
+            if security_name == min_security:
+                break
+
+        # At this point, we know we have to make a new connection.
+        # NPN/ALPN can override alt-svc knowledge (for absence), but only if the server and client both support it
+
+        sock = self._socket_factory(host, port)
+
+        # Get the minimum security, and keep bumping it up as long as we're
+        # allowed to.
+
+        start_security = False
+        selected_protocol = None
+        # all the protocols we're willing to speak, i.e. those with
+        # min_protocol's precedence or higher - reversed to indicate our
+        # preference to the server
+        supported_protocols = [protocol[0] for protocol in reversed(list(itertools.dropwhile(lambda protocol: protocol[0] != min_protocol, self._registered_protocols)))]
+        selected_security = None
+        for name, factory, upgrade in self._registered_securities:
+            if name == min_security:
+                start_security = True
+                selected_security = name
+                sock, selected_protocol = factory(sock, host, port, supported_protocols)
+            elif start_security:
+                if upgrade is None:
+                    break
+                retval = upgrade(sock, host, port, supported_protocols)
+                if retval is None:
+                    # upgrade was unsuccessful
+                    break
+                selected_security = name
+                sock, selected_protocol = retval
+
+        if selected_protocol is None:
+            # we didn't negotiate a protocol through NPN/ALPN, so look for a
+            # singleton unexpired protocol we know the server speaks
+            for protocol in supported_protocols:
+                expiry = self._known_services.get((host, port, selected_security, protocol), 0)
+                if expiry is None or expiry > time.time():
+                    if selected_protocol is not None:
+                        raise MultipleKnownProtocols()
+                    selected_protocol = protocol
+            if selected_protocol is None:
+                # we didn't find a fresh known protocol, so assume the server
+                # speaks the first registered protocol (usually 'h1')
+                selected_protocol = self._registered_protocols[0][0]
+
+        reached_minimum = False
+        for name, factory, single_conn in self._registered_protocols:
+            if name == min_protocol:
+                reached_minimum = True
+            if name == selected_protocol:
+                # ensure the selected protocol has at least min_protocol's precedence
+                if not reached_minimum:
+                    raise UnsupportedMinProtocol()
+                tracker = Tracker(self, host, port, selected_security, selected_protocol)
+                connection = factory(sock, host, port, tracker)
+                tracker.conn = connection
+                if single_conn:
+                    self._connections.setdefault((host, port, selected_security, selected_protocol), []).append(connection)
+                return (connection, selected_security, selected_protocol)
+
+    def relinquish(self, conn, host, port, security, protocol):
+        self._connections.setdefault((host, port, security, protocol), []).append(conn)
+
+    # called post-Upgrade dance
+    def switch_protocol(self, conn, host, port, security, old_protocol, new_protocol):
+        for name, factory, single_conn in self._registered_protocols:
+            if single_conn:
+                if name == old_protocol:
+                    conns = self._connections[(host, port, security, old_protocol)]
+                    conns.remove(conn)
+                if name == new_protocol:
+                    self._connections.setdefault((host, port, security, new_protocol), []).append(conn)
+
+    # works for both alt-svc and prior knowledge
+    # expiry=None --> "never expire"
+    def add_known_service(self, host, port, security, protocol, expiry=None, src_address=None):
+        self._known_services[(host, port, security, protocol)] = expiry
+        if src_address is not None:
+            self.alt_services[src_address] = (host, port) # TODO use somewhere
+
+    def _register(self, coll, thing, pred):
+        if pred is None:
+            coll.append(thing)
+        else:
+            idx = [i for i in range(len(coll)) if coll[i][0] == pred][0]
+            coll.insert(idx+1, thing)
+
+    def register_security(self, name, pred, factory, upgrade=None):
+        self._register(self._registered_securities, (name, factory, upgrade), pred)
+
+    def register_protocol(self, name, pred, factory, single_conn=True):
+        self._register(self._registered_protocols, (name, factory, single_conn), pred)
+
+    @staticmethod
+    def register_defaults(pool):
+        pool.register_security('null', None, lambda sock, host, port, protocols: (sock, None))
+        pool.register_security('weak', 'null', weak_security)
+        pool.register_security('strong', 'weak', strong_security, lambda sock, host, port, protocols: (sock, None)) # FIXME real upgrade()
+        pool.register_protocol('h1', None, HTTP11Protocol, False)
+        pool.register_protocol('h2', 'h1', HTTP20Protocol)
+
+
+_pool = SmartPool()
+SmartPool.register_defaults(_pool)

--- a/test/test_pool.py
+++ b/test/test_pool.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+import unittest
+
+from hyper.pool import SmartPool, HTTP20Protocol, UnsupportedMinProtocol, UpgradedConnection
+
+
+security_noop = lambda sock, host, port, protocols: (sock, None)
+protocol_noop = lambda sock, host, port, tracker: DummyConnection(sock)
+
+class DummyConnection(object):
+    def __init__(self, sock):
+        self.sock = sock
+
+
+def register_noops(pool, disable_upgrade=False):
+    disabled_upgrade = lambda sock, host, port, protocols: None
+    pool.register_security('null', None, security_noop)
+    pool.register_security('weak', 'null', security_noop) # don't actually do the handshake
+    pool.register_security('strong', 'weak', security_noop,
+        security_noop if not disable_upgrade else disabled_upgrade)
+    pool.register_protocol('h1', None, protocol_noop, single_conn=False)
+    pool.register_protocol('h2', 'h1', protocol_noop)
+
+
+class TestPool(unittest.TestCase):
+    def test_multi_conn_not_reused(self):
+        # TODO use fixture - new Pool for each test
+        pool = SmartPool()
+        pool.register_security('null', None, security_noop)
+        pool.register_protocol('h1', None, protocol_noop, single_conn=False)
+
+        conn, security, protocol = pool.get('google.com', 80, 'null', 'h1')
+        assert protocol == 'h1'
+        assert security == 'null'
+
+        conn2 = pool.get('google.com', 80, 'null', 'h1')[0]
+        assert conn2 is not conn
+
+    def test_single_conn_reused(self):
+        pool = SmartPool()
+        pool.register_security('null', None, security_noop)
+        pool.register_protocol('h1', None, protocol_noop, single_conn=True)
+
+        conn, security, protocol = pool.get('google.com', 80, 'null', 'h1')
+        assert protocol == 'h1'
+        assert security == 'null'
+
+        conn2 = pool.get('google.com', 80, 'null', 'h1')[0]
+        assert conn2 is conn
+
+    def test_h2_unavailable_without_npn(self):
+        pool = SmartPool()
+        register_noops(pool)
+
+        self.assertRaises(UnsupportedMinProtocol, pool.get, 'google.com', 80, 'null', 'h2')
+
+    def test_upgrade_h1_to_h2(self):
+        pool = SmartPool()
+        SmartPool.register_defaults(pool)
+
+        class Response(object):
+            status = 101
+            will_close = False
+            def __init__(self, *args, **kwargs):
+                pass
+            def begin(self):
+                pass
+            def getheader(self, name):
+                return dict(Connection='Upgrade', Upgrade='h2')[name]
+
+        conn = pool.get('google.com', 80, 'null', 'h1')[0]
+        conn.response_class = Response
+        conn.request('GET', '/')
+        try:
+            response = conn.getresponse()
+            assert False, "didn't raise UpgradedConnection"
+        except UpgradedConnection as e:
+            new_conn = e.conn
+
+        assert isinstance(new_conn, HTTP20Protocol)
+        conn2 = pool.get('google.com', 80, 'null', 'h2')[0]
+        assert conn is conn2
+
+        # TODO test handling server that doesn't support Upgrade
+        # TODO add Upgrade support to nghttp2
+
+    def test_weak_security_cascade(self):
+        pool = SmartPool()
+        register_noops(pool, disable_upgrade=True)
+
+        pool.add_known_service('google.com', 80, 'weak', 'h2')
+        pool.get('google.com', 80, 'weak', 'h2')
+        conn, security, protocol = pool.get('google.com', 80, 'null', 'h2')
+        assert security == 'weak'
+
+        conn, security, protocol = pool.get('google.com', 80, 'weak', 'h2')
+        assert security == 'weak'
+
+    def test_strong_security_cascade(self):
+        pool = SmartPool()
+        register_noops(pool, disable_upgrade=True)
+
+        pool.add_known_service('google.com', 80, 'strong', 'h2')
+        pool.get('google.com', 80, 'strong', 'h2')
+        conn, security, protocol = pool.get('google.com', 80, 'null', 'h2')
+        assert security == 'strong'
+
+        conn, security, protocol = pool.get('google.com', 80, 'weak', 'h2')
+        assert security == 'strong'
+
+        conn, security, protocol = pool.get('google.com', 80, 'strong', 'h2')
+        assert security == 'strong'
+
+    def test_upgrade_weak_to_strong_security(self):
+        pool = SmartPool()
+        register_noops(pool)
+
+        # TODO should this work if security=weak is a known service? at least try to upgrade it?
+        pool.add_known_service('google.com', 80, 'strong', 'h2')
+        conn = pool.get('google.com', 80, 'weak', 'h2')[0]
+        conn2, security, protocol = pool.get('google.com', 80, 'strong', 'h2')
+        assert security == 'strong'
+        assert conn is conn2
+
+    def test_h2_available_with_npn(self):
+        pool = SmartPool()
+        pool.register_security('strong', None, lambda sock, host, port, protocols: (sock, 'h2'))
+        pool.register_protocol('h1', None, protocol_noop, single_conn=False)
+        pool.register_protocol('h2', 'h1', protocol_noop)
+
+        conn, security, protocol = pool.get('google.com', 80, 'strong', 'h1')
+        assert protocol == 'h2'
+
+
+# return Tracker object, rather than connection - users can get it from Tracker.conn
+# relinquishing
+# socket closing (from server side)
+# alt-svc logic


### PR DESCRIPTION
After trying a couple times to come up with a design for `Alt-Svc` or `Upgrade` support, I realized the logic needs to be contained in a connection pool class. This turned out to be a powerful abstraction - for example, if an HTTP/1.1 connection is requested to a given host, and we have a pre-existing HTTP/2.0 connection, we can return the latter instead (this is where @lukasa's decision to mimic the standard `HTTPConnection` API was prescient). Similarly, a request for an unencrypted connection may return an encrypted one.

After reading [the opportunistic encryption IETF draft](http://tools.ietf.org/html/draft-nottingham-http2-encryption-02#section-2), I've decided to include three default security levels: null (no encryption), weak (encryption w/o hostname verification or certificate validation), and strong (encryption with all the bells and whistles). Perhaps the "weak" category could also include connections with broken or non-PFS ciphers in the future.

Note that for HTTP/2.0 connections, the class doesn't function as a traditional connection pool: rather than removing connections from the pool, processing a request/response pair, and returning them to the pool, they are used for multiple concurrent request streams.

Additionally, upgrading an HTTP/1.1 connection to HTTP/2.0 is exposed in an unusual way: to ensure the user handles the switch properly (since HTTP/1.1 can no longer be spoken on the socket), an `UpgradedConnection` exception is raised from `getresponse()` if the `Upgrade` dance completed successfully (i.e. the server returned a `101` response with the proper header fields).

This is meant as a proof-of-concept only - the code is less than stellar, minimally tested, and almost certainly does not work against real servers; I haven't even bothered to try it. It's also quite complicated, mostly due to my decision to make it extensible by introducing a precedence hierarchy for both protocols and security levels (it did come in handy for testing, though). Hopefully a lot of the list iteration can be factored out into utility functions in the future. In addition, it doesn't offer much of the functionality of the `HTTP(S)ConnectionPool` class in urllib3, but we could remedy that soon as well.