### PR TITLE
HTTP/2 dumping tool

### DIFF
--- a/http2dump
+++ b/http2dump
@@ -15,6 +15,9 @@ Options:
   -h, --help    Show this screen.
   --version     Show version.
 """
+# Version compatibility
+from __future__ import print_function
+
 from docopt import docopt
 import hyper
 

--- a/http2dump
+++ b/http2dump
@@ -7,13 +7,14 @@ Decodes a binary stream of HTTP/2 data into a textual representation of the
 encoded frame data.
 
 Usage:
-  http2dump infile
+  http2dump [options] infile
   http2dump -h | --help
   http2dump --version
 
 Options:
-  -h, --help    Show this screen.
-  --version     Show version.
+  -o <outfile>, --output=<outfile>   File to write output to instead of stdout.
+  -h, --help                         Show this screen.
+  --version                          Show version.
 """
 # Version compatibility
 from __future__ import print_function
@@ -21,7 +22,7 @@ from __future__ import print_function
 from docopt import docopt
 import hyper
 
-def main(infile=None):
+def main(infile=None, outfile=None):
     """
     The main http2dump loop.
 

--- a/http2dump
+++ b/http2dump
@@ -53,4 +53,5 @@ if __name__ == '__main__':
     infile = options['<infile>']
     outfile = options.get('output', sys.stdout)
 
-    main(infile, outfile)
+    with open(infile, 'rb') as infile:
+        main(infile, outfile)

--- a/http2dump
+++ b/http2dump
@@ -52,9 +52,11 @@ def main(infile=None, outfile=None):
         body = infile.read(length)
         frame.parse_body(memoryview(body))
 
+        frame_data = frame.to_json_obj()
+
         # Done! In this early iteration of the script, we'll just print the
         # frame types to stdout.
-        print(frame.__class__.__name__)
+        print(frame_data['type'])
 
 
 if __name__ == '__main__':

--- a/http2dump
+++ b/http2dump
@@ -37,6 +37,8 @@ def main(infile=None, outfile=None):
     The loop terminates when the binary file is exhausted.
     """
     # Read the HTTP/2 preamble (24 byes).
+    # FIXME: This makes the assumption that we're looking at a client stream.
+    # For now that's fine, but we'll need to fix it later.
     infile.read(24)
 
     while True:

--- a/http2dump
+++ b/http2dump
@@ -36,6 +36,9 @@ def main(infile=None, outfile=None):
 
     The loop terminates when the binary file is exhausted.
     """
+    # Read the HTTP/2 preamble (24 byes).
+    infile.read(24)
+
     while True:
         # Parse the frame.
         frame_header = infile.read(9)

--- a/http2dump
+++ b/http2dump
@@ -39,7 +39,7 @@ def main(infile=None, outfile=None):
     while True:
         # Parse the frame.
         frame_header = infile.read(9)
-        frame, length = hyper.http20.Frame.parse_frame_header(frame_header)
+        frame, length = hyper.http20.frame.Frame.parse_frame_header(frame_header)
         body = infile.read(length)
         frame.parse_body(body)
 

--- a/http2dump
+++ b/http2dump
@@ -44,7 +44,7 @@ def main(infile=None, outfile=None):
         frame_header = infile.read(9)
         frame, length = hyper.http20.frame.Frame.parse_frame_header(frame_header)
         body = infile.read(length)
-        frame.parse_body(body)
+        frame.parse_body(memoryview(body))
 
         # Done! In this early iteration of the script, we'll just print the
         # frame types to stdout.

--- a/http2dump
+++ b/http2dump
@@ -19,8 +19,11 @@ Options:
 # Version compatibility
 from __future__ import print_function
 
+import sys
+
 from docopt import docopt
 import hyper
+
 
 def main(infile=None, outfile=None):
     """
@@ -47,5 +50,7 @@ def main(infile=None, outfile=None):
 
 if __name__ == '__main__':
     options = docopt(__doc__, help=True, version=hyper.__version__)
+    infile = options['<infile>']
+    outfile = options.get('output', sys.stdout)
 
-    main(**options)
+    main(infile, outfile)

--- a/http2dump
+++ b/http2dump
@@ -46,6 +46,6 @@ def main(infile=None, outfile=None):
 
 
 if __name__ == '__main__':
-    options = docopt(__doc__, help=True, version=hyper.version)
+    options = docopt(__doc__, help=True, version=hyper.__version__)
 
     main(**options)

--- a/http2dump
+++ b/http2dump
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
 http2dump

--- a/http2dump
+++ b/http2dump
@@ -7,7 +7,7 @@ Decodes a binary stream of HTTP/2 data into a textual representation of the
 encoded frame data.
 
 Usage:
-  http2dump [options] infile
+  http2dump [options] <infile>
   http2dump -h | --help
   http2dump --version
 

--- a/http2dump
+++ b/http2dump
@@ -42,6 +42,10 @@ def main(infile=None, outfile=None):
     while True:
         # Parse the frame.
         frame_header = infile.read(9)
+
+        if not frame_header:
+            break
+
         frame, length = hyper.http20.frame.Frame.parse_frame_header(frame_header)
         body = infile.read(length)
         frame.parse_body(memoryview(body))

--- a/http2dump
+++ b/http2dump
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""
+http2dump
+
+Decodes a binary stream of HTTP/2 data into a textual representation of the
+encoded frame data.
+
+Usage:
+  http2dump infile
+  http2dump -h | --help
+  http2dump --version
+
+Options:
+  -h, --help    Show this screen.
+  --version     Show version.
+"""
+from docopt import docopt
+import hyper
+
+def main(infile=None):
+    """
+    The main http2dump loop.
+
+    Generally, this loop executes as follows:
+      - Read from the binary file until a frame is decoded.
+      - Print the frame to stdout.
+      - Repeat
+
+    The loop terminates when the binary file is exhausted.
+    """
+    pass
+
+if __name__ == '__main__':
+    options = docopt(__doc__, help=True, version=hyper.version)
+
+    main(**options)

--- a/http2dump
+++ b/http2dump
@@ -32,7 +32,17 @@ def main(infile=None):
 
     The loop terminates when the binary file is exhausted.
     """
-    pass
+    while True:
+        # Parse the frame.
+        frame_header = infile.read(9)
+        frame, length = hyper.http20.Frame.parse_frame_header(frame_header)
+        body = infile.read(length)
+        frame.parse_body(body)
+
+        # Done! In this early iteration of the script, we'll just print the
+        # frame types to stdout.
+        print(frame.__class__.__name__)
+
 
 if __name__ == '__main__':
     options = docopt(__doc__, help=True, version=hyper.version)

--- a/hyper/http20/frame.py
+++ b/hyper/http20/frame.py
@@ -10,6 +10,9 @@ socket.
 import collections
 import struct
 
+from binascii import hexlify
+
+
 # The maximum length of a frame. Some frames have shorter maximum lengths.
 FRAME_MAX_LEN = (2 ** 14) - 1
 
@@ -221,6 +224,13 @@ class DataFrame(Padding, Frame):
     def parse_body(self, data):
         padding_data_length = self.parse_padding_data(data)
         self.data = data[padding_data_length:len(data)-self.total_padding].tobytes()
+
+    def diag_serialize_body(self):
+        def chunks(string):
+            chunk_size = 68
+            for i in range(0, len(string), chunk_size):
+                yield '  ' + string[i:i+chunk_size]
+        return '\n'.join(chunks(hexlify(self.data).decode('utf-8')))
 
     @property
     def flow_controlled_length(self):

--- a/hyper/http20/frame.py
+++ b/hyper/http20/frame.py
@@ -129,6 +129,11 @@ class Padding(object):
             return 1
         return 0
 
+    def diag_serialize_padding_data(self):
+        if 'PADDED' in self.flags:
+            return '(%d padding bytes)' % self.pad_length
+        return ''
+
     @property
     def total_padding(self):
         """Return the total length of the padding, if any."""
@@ -166,6 +171,17 @@ class Priority(object):
         self.exclusive = bool(self.depends_on & MASK)
         self.depends_on &= ~MASK
         return 5
+
+    def diag_serialize_priority_data(self):
+        base = 'Priority: Depends on %d, weight %d' % (
+            self.depends_on, self.stream_weight
+        )
+        if self.exclusive:
+            exclusive = ' (Exclusive)'
+        else:
+            exclusive = ''
+
+        return ''.join(base, exclusive)
 
 
 class DataFrame(Padding, Frame):

--- a/hyper/http20/frame.py
+++ b/hyper/http20/frame.py
@@ -131,7 +131,7 @@ class Padding(object):
 
     def diag_serialize_padding_data(self):
         if 'PADDED' in self.flags:
-            return '(%d padding bytes)' % self.pad_length
+            return ' (%d padding bytes)' % self.pad_length
         return ''
 
     @property
@@ -173,7 +173,7 @@ class Priority(object):
         return 5
 
     def diag_serialize_priority_data(self):
-        base = 'Priority: Depends on %d, weight %d' % (
+        base = '  Priority: Depends on %d, weight %d' % (
             self.depends_on, self.stream_weight
         )
         if self.exclusive:

--- a/hyper/http20/frame.py
+++ b/hyper/http20/frame.py
@@ -413,6 +413,13 @@ class PingFrame(Frame):
 
         self.opaque_data = data.tobytes()
 
+    def to_json_obj(self, dump_body=False):
+        data = super(PingFrame, self).to_json_obj(False)
+        data['PING'] = {
+            'opaque data': hexlify(self.opaque_data).decode('ascii')
+        }
+        return data
+
 
 class GoAwayFrame(Frame):
     """

--- a/hyper/http20/frame.py
+++ b/hyper/http20/frame.py
@@ -201,7 +201,7 @@ class Priority(object):
         else:
             exclusive = ''
 
-        return ''.join(base, exclusive)
+        return ''.join([base, exclusive])
 
 
 class DataFrame(Padding, Frame):
@@ -267,6 +267,9 @@ class PriorityFrame(Priority, Frame):
 
     def parse_body(self, data):
         self.parse_priority_data(data)
+
+    def diag_serialize_body(self):
+        return ''
 
 
 class RstStreamFrame(Frame):

--- a/hyper/http20/frame.py
+++ b/hyper/http20/frame.py
@@ -90,14 +90,23 @@ class Frame(object):
         """
         # Get some useful info
         body = self.serialize_body_diag()
-        body_len = len(self.serialize_body())
 
         name = self.__class__.__name__.upper()
         stream_id = '  Stream ID: %d' % self.stream_id
         flags = '  Flags: %s' % (', '.join(self.flags))
         length = '  Length: %d' % len(self.serialize_body())
 
-        return '\n'.join(name, stream_id, flags, length, body, '')
+        if hasattr(self, 'diag_serialize_padding_data'):
+            length += self.diag_serialize_padding_data()
+
+        parts = [name, stream_id, flags, length, body]
+
+        if hasattr(self, 'diag_serialize_priority_data'):
+            parts.append(self.diag_serialize_priority_data())
+
+        parts.append('')
+
+        return '\n'.join(parts)
 
     def serialize_body(self):
         raise NotImplementedError()

--- a/hyper/http20/frame.py
+++ b/hyper/http20/frame.py
@@ -91,10 +91,14 @@ class Frame(object):
         Serialize a frame for diagnostic purposes. Prints a human-readable
         representation of the frame.
         """
-
         name = self.__class__.__name__.upper()[:-5]  # Drop the 'FRAME' chars.
         stream_id = '  Stream ID: %d' % self.stream_id
-        flags = '  Flags: %s' % (', '.join(self.flags))
+
+        if self.flags:
+            flags = '  Flags: %s' % (', '.join(self.flags))
+        else:
+            flags = '  Flags: None'
+
         length = '  Length: %d' % len(self.serialize_body())
 
         if hasattr(self, 'diag_serialize_padding_data'):

--- a/hyper/http20/frame.py
+++ b/hyper/http20/frame.py
@@ -91,8 +91,6 @@ class Frame(object):
         Serialize a frame for diagnostic purposes. Prints a human-readable
         representation of the frame.
         """
-        # Get some useful info
-        body = self.diag_serialize_body()
 
         name = self.__class__.__name__.upper()[:-5]  # Drop the 'FRAME' chars.
         stream_id = '  Stream ID: %d' % self.stream_id
@@ -102,7 +100,12 @@ class Frame(object):
         if hasattr(self, 'diag_serialize_padding_data'):
             length += self.diag_serialize_padding_data()
 
-        parts = [name, stream_id, flags, length, body]
+        parts = [name, stream_id, flags, length]
+
+        body = self.diag_serialize_body()
+
+        if body:
+            parts.append(body)
 
         if hasattr(self, 'diag_serialize_priority_data'):
             parts.append(self.diag_serialize_priority_data())

--- a/hyper/http20/frame.py
+++ b/hyper/http20/frame.py
@@ -455,6 +455,15 @@ class GoAwayFrame(Frame):
         if len(data) > 8:
             self.additional_data = data[8:].tobytes()
 
+    def to_json_obj(self, dump_body=False):
+        data = super(GoAwayFrame, self).to_json_obj(False)
+        data['GOAWAY'] = {
+            'last stream id': self.last_stream_id,
+            'error code': self.error_code,
+            'additional data': hexlify(self.additional_data).decode('ascii'),
+        }
+        return data
+
 
 class WindowUpdateFrame(Frame):
     """

--- a/hyper/http20/frame.py
+++ b/hyper/http20/frame.py
@@ -104,13 +104,6 @@ class Frame(object):
             'body': None,
         }
 
-        if hasattr(self, 'depends_on'):
-            data['priority'] = {
-                'depends on': self.depends_on,
-                'stream weight': self.stream_weight,
-                'exclusive': self.exclusive,
-            }
-
         if dump_body:
             data['body'] = hexlify(self.serialize_body())
 
@@ -189,6 +182,15 @@ class Priority(object):
         self.exclusive = bool(self.depends_on & MASK)
         self.depends_on &= ~MASK
         return 5
+
+    def to_json_obj(self, dump_body=False):
+        data = super(Priority, self).to_json_obj(dump_body)
+        data['priority'] = {
+            'depends on': self.depends_on,
+            'stream weight': self.stream_weight,
+            'exclusive': self.exclusive,
+        }
+        return data
 
 
 class DataFrame(Padding, Frame):

--- a/hyper/http20/frame.py
+++ b/hyper/http20/frame.py
@@ -376,6 +376,11 @@ class PushPromiseFrame(Padding, Frame):
         self.promised_stream_id = struct.unpack("!L", data[padding_data_length:padding_data_length + 4])[0]
         self.data = data[padding_data_length + 4:].tobytes()
 
+    def to_json_obj(self, dump_body=False):
+        data = super(PushPromiseFrame, self).to_json_obj(False)
+        data['PUSH_PROMISE'] = {'promised stream id': self.promised_stream_id}
+        return data
+
 
 class PingFrame(Frame):
     """

--- a/hyper/http20/frame.py
+++ b/hyper/http20/frame.py
@@ -320,6 +320,16 @@ class SettingsFrame(Frame):
     SETTINGS_MAX_FRAME_SIZE       = 0x05
     SETTINGS_MAX_HEADER_LIST_SIZE = 0x06
 
+    # Define a reverse mapping as well.
+    text_names = {
+        0x01: 'HEADER_TABLE_SIZE',
+        0x02: 'ENABLE_PUSH',
+        0x03: 'MAX_CONCURRENT_STREAMS',
+        0x04: 'INITIAL_WINDOW_SIZE',
+        0x05: 'SETTINGS_MAX_FRAME_SIZE',
+        0x06: 'SETTINGS_MAX_HEADER_LIST_SIZE',
+    }
+
     def __init__(self, stream_id):
         super(SettingsFrame, self).__init__(stream_id)
 
@@ -335,6 +345,13 @@ class SettingsFrame(Frame):
         for i in range(0, len(data), 6):
             name, value = struct.unpack("!HL", data[i:i+6])
             self.settings[name] = value
+
+    def to_json_obj(self, dump_body=False):
+        data = super(SettingsFrame, self).to_json_obj(False)
+        data['SETTINGS'] = {
+            self.text_names[k]: v for k,v in self.settings.items()
+        }
+        return data
 
 
 class PushPromiseFrame(Padding, Frame):

--- a/hyper/http20/frame.py
+++ b/hyper/http20/frame.py
@@ -99,7 +99,7 @@ class Frame(object):
         data = {
             'type': self.__class__.__name__.upper()[:-5],
             'stream id': self.stream_id,
-            'flags': self.flags,
+            'flags': list(self.flags),
             'length': len(self.serialize_body()),
             'body': None,
         }

--- a/hyper/http20/frame.py
+++ b/hyper/http20/frame.py
@@ -104,9 +104,6 @@ class Frame(object):
             'body': None,
         }
 
-        if hasattr(self, 'total_padding'):
-            data['padding length'] = self.total_padding
-
         if hasattr(self, 'depends_on'):
             data['priority'] = {
                 'depends on': self.depends_on,
@@ -145,6 +142,15 @@ class Padding(object):
             self.pad_length = struct.unpack('!B', data[:1])[0]
             return 1
         return 0
+
+    def to_json_obj(self, dump_body=False):
+        data = super(Padding, self).to_json_obj(dump_body)
+        data['padding length'] = self.total_padding
+
+        if 'PADDED' in self.flags:
+            data['padding length'] += 1
+
+        return data
 
     @property
     def total_padding(self):

--- a/hyper/http20/frame.py
+++ b/hyper/http20/frame.py
@@ -142,8 +142,9 @@ class Padding(object):
         return 0
 
     def diag_serialize_padding_data(self):
+        # Make sure to add 1 to the padding length to include the length byte.
         if 'PADDED' in self.flags:
-            return ' (%d padding bytes)' % self.pad_length
+            return ' (%d padding bytes)' % (self.pad_length + 1)
         return ''
 
     @property

--- a/hyper/http20/frame.py
+++ b/hyper/http20/frame.py
@@ -280,6 +280,18 @@ class RstStreamFrame(Frame):
 
         self.error_code = struct.unpack("!L", data)[0]
 
+    def to_json_obj(self, dump_body=False):
+        # Never serialize the body
+        dump_body = False
+        data = super(RstStreamFrame, self).to_json_obj(dump_body)
+
+        # Add the custom data.
+        data['RST_STREAM'] = {
+            'error code': self.error_code
+        }
+
+        return data
+
 
 class SettingsFrame(Frame):
     """

--- a/hyper/http20/frame.py
+++ b/hyper/http20/frame.py
@@ -101,16 +101,15 @@ class Frame(object):
             'stream id': self.stream_id,
             'flags': self.flags,
             'length': len(self.serialize_body()),
-            'padding length': None,
+            'padding length': 0,
             'body': None,
-            'priority': None,
         }
 
         if hasattr(self, 'total_padding'):
             data['padding length'] = self.total_padding
 
         if hasattr(self, 'depends_on'):
-            data['padding'] = {
+            data['priority'] = {
                 'depends on': self.depends_on,
                 'stream weight': self.stream_weight,
                 'exclusive': self.exclusive,

--- a/hyper/http20/frame.py
+++ b/hyper/http20/frame.py
@@ -493,6 +493,13 @@ class WindowUpdateFrame(Frame):
     def parse_body(self, data):
         self.window_increment = struct.unpack("!L", data)[0]
 
+    def to_json_obj(self, dump_body=False):
+        data = super(WindowUpdateFrame, self).to_json_obj(False)
+        data['WINDOWUPDATE'] = {
+            'window increment': self.window_increment,
+        }
+        return data
+
 
 class HeadersFrame(Padding, Priority, Frame):
     """

--- a/hyper/http20/frame.py
+++ b/hyper/http20/frame.py
@@ -121,7 +121,7 @@ class Frame(object):
     def serialize_body(self):
         raise NotImplementedError()
 
-    def diag_serialize_body(self):
+    def diag_serialize_body(self):  # pragma: no cover
         raise NotImplementedError()
 
     def parse_body(self, data):

--- a/hyper/http20/frame.py
+++ b/hyper/http20/frame.py
@@ -91,7 +91,7 @@ class Frame(object):
         # Get some useful info
         body = self.diag_serialize_body()
 
-        name = self.__class__.__name__.upper()
+        name = self.__class__.__name__.upper()[:-5]  # Drop the 'FRAME' chars.
         stream_id = '  Stream ID: %d' % self.stream_id
         flags = '  Flags: %s' % (', '.join(self.flags))
         length = '  Length: %d' % len(self.serialize_body())

--- a/hyper/http20/frame.py
+++ b/hyper/http20/frame.py
@@ -105,7 +105,7 @@ class Frame(object):
         }
 
         if dump_body:
-            data['body'] = hexlify(self.serialize_body())
+            data['body'] = hexlify(self.serialize_body()).decode('ascii')
 
         return data
 

--- a/hyper/http20/frame.py
+++ b/hyper/http20/frame.py
@@ -83,7 +83,26 @@ class Frame(object):
 
         return header + body
 
+    def diag_serialize(self):
+        """
+        Serialize a frame for diagnostic purposes. Prints a human-readable
+        representation of the frame.
+        """
+        # Get some useful info
+        body = self.serialize_body_diag()
+        body_len = len(self.serialize_body())
+
+        name = self.__class__.__name__.upper()
+        stream_id = '  Stream ID: %d' % self.stream_id
+        flags = '  Flags: %s' % (', '.join(self.flags))
+        length = '  Length: %d' % len(self.serialize_body())
+
+        return '\n'.join([name, stream_id, flags, length, body, ''])
+
     def serialize_body(self):
+        raise NotImplementedError()
+
+    def serialize_body_diag(self):
         raise NotImplementedError()
 
     def parse_body(self, data):

--- a/hyper/http20/frame.py
+++ b/hyper/http20/frame.py
@@ -89,7 +89,7 @@ class Frame(object):
         representation of the frame.
         """
         # Get some useful info
-        body = self.serialize_body_diag()
+        body = self.diag_serialize_body()
 
         name = self.__class__.__name__.upper()
         stream_id = '  Stream ID: %d' % self.stream_id
@@ -111,7 +111,7 @@ class Frame(object):
     def serialize_body(self):
         raise NotImplementedError()
 
-    def serialize_body_diag(self):
+    def diag_serialize_body(self):
         raise NotImplementedError()
 
     def parse_body(self, data):

--- a/hyper/http20/frame.py
+++ b/hyper/http20/frame.py
@@ -101,7 +101,6 @@ class Frame(object):
             'stream id': self.stream_id,
             'flags': self.flags,
             'length': len(self.serialize_body()),
-            'padding length': 0,
             'body': None,
         }
 

--- a/hyper/http20/frame.py
+++ b/hyper/http20/frame.py
@@ -97,7 +97,7 @@ class Frame(object):
         flags = '  Flags: %s' % (', '.join(self.flags))
         length = '  Length: %d' % len(self.serialize_body())
 
-        return '\n'.join([name, stream_id, flags, length, body, ''])
+        return '\n'.join(name, stream_id, flags, length, body, '')
 
     def serialize_body(self):
         raise NotImplementedError()

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -649,6 +649,20 @@ class TestContinuationFrame(object):
         assert f.flags == set(['END_HEADERS'])
         assert f.data == b'hello world'
 
+    def test_headers_frame_without_priority_json_serializes_properly(self):
+        f = ContinuationFrame(1)
+        f.flags = ['END_HEADERS']
+        f.data = b'\x01\x02\x03\x04'
+        result = {
+            'type': 'CONTINUATION',
+            'stream id': 1,
+            'flags': ['END_HEADERS'],
+            'length': 4,
+            'body': None,
+        }
+
+        assert f.to_json_obj() == result
+
 
 class TestAltSvcFrame(object):
     payload_with_origin = (

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -602,6 +602,26 @@ class TestHeadersFrame(object):
 
         assert f.serialize() == s
 
+    def test_headers_frame_without_priority_json_serializes_properly(self):
+        f = HeadersFrame(1)
+        f.flags = ['END_STREAM', 'END_HEADERS']
+        f.data = b'\x01\x02\x03\x04'
+        result = {
+            'type': 'HEADERS',
+            'stream id': 1,
+            'flags': ['END_STREAM', 'END_HEADERS'],
+            'length': 4,
+            'body': None,
+            'padding length': 0,
+            'priority': {
+                'depends on': None,
+                'exclusive': None,
+                'stream weight': None,
+            }
+        }
+
+        assert f.to_json_obj() == result
+
 
 class TestContinuationFrame(object):
     def test_continuation_frame_flags(self):

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -52,6 +52,11 @@ class TestGeneralFrameBehaviour(object):
         with pytest.raises(NotImplementedError):
             f.parse_body(data)
 
+    def test_base_frame_doesnt_diag_serialize(self):
+        f = Frame(0)
+        with pytest.raises(NotImplementedError):
+            f.diag_serialize()
+
 
 class TestDataFrame(object):
     payload = b'\x00\x00\x08\x00\x01\x00\x00\x00\x01testdata'

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -137,6 +137,24 @@ class TestDataFrame(object):
 
         assert f.diag_serialize() == result
 
+    def test_data_frame_with_padding_diag_serializes_properly(self):
+        f = DataFrame(1)
+        f.flags = ['END_STREAM', 'PADDED']  # Don't use a set, be predictable
+        f.data = b'\x01' * 80
+        f.pad_length = 10
+
+        result = (
+            "DATA\n"
+            "  Stream ID: 1\n"
+            "  Flags: END_STREAM, PADDED\n"
+            "  Length: 91 (11 padding bytes)\n"
+            "  " + "01"*34 + "\n"
+            "  " + "01"*34 + "\n"
+            "  " + "01"*12 + "\n"
+        )
+
+        assert f.diag_serialize() == result
+
 
 class TestPriorityFrame(object):
     payload = b'\x00\x00\x05\x02\x00\x00\x00\x00\x01\x80\x00\x00\x04\x40'

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -305,6 +305,28 @@ class TestSettingsFrame(object):
         assert f.flags == set(['ACK'])
         assert f.settings == self.settings
 
+    def test_settings_frame_to_json(self):
+        f = SettingsFrame(0)
+        f.parse_flags(0xFF)
+        f.settings = self.settings
+        result = {
+            'type': 'SETTINGS',
+            'stream id': 0,
+            'flags': ['ACK'],
+            'length': 36,
+            'body': None,
+            'SETTINGS': {
+                'HEADER_TABLE_SIZE': 4096,
+                'ENABLE_PUSH': 0,
+                'MAX_CONCURRENT_STREAMS': 100,
+                'INITIAL_WINDOW_SIZE': 65535,
+                'SETTINGS_MAX_FRAME_SIZE': 16384,
+                'SETTINGS_MAX_HEADER_LIST_SIZE': 65535,
+            }
+        }
+
+        assert f.to_json_obj() == result
+
     def test_settings_frames_never_have_streams(self):
         with pytest.raises(ValueError):
             SettingsFrame(1)

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -186,6 +186,38 @@ class TestPriorityFrame(object):
         with pytest.raises(ValueError):
             PriorityFrame(0)
 
+    def test_priority_frame_with_exclusive_diag_serializes_properly(self):
+        f = PriorityFrame(1)
+        f.depends_on = 0x04
+        f.stream_weight = 64
+        f.exclusive = True
+
+        result = (
+            "PRIORITY\n"
+            "  Stream ID: 1\n"
+            "  Flags: None\n"
+            "  Length: 5\n"
+            "  Priority: Depends on 4, weight 64 (Exclusive)\n"
+        )
+
+        assert f.diag_serialize() == result
+
+    def test_priority_frame_without_exclusive_diag_serializes_properly(self):
+        f = PriorityFrame(1)
+        f.depends_on = 0x04
+        f.stream_weight = 64
+        f.exclusive = False
+
+        result = (
+            "PRIORITY\n"
+            "  Stream ID: 1\n"
+            "  Flags: None\n"
+            "  Length: 5\n"
+            "  Priority: Depends on 4, weight 64\n"
+        )
+
+        assert f.diag_serialize() == result
+
 
 class TestRstStreamFrame(object):
     def test_rst_stream_frame_has_no_flags(self):

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -523,6 +523,22 @@ class TestWindowUpdateFrame(object):
         assert f.flags == set()
         assert f.window_increment == 512
 
+    def test_goaway_frame_json_serializes_properly(self):
+        f = WindowUpdateFrame(0)
+        f.window_increment = 512
+        result = {
+            'type': 'WINDOWUPDATE',
+            'stream id': 0,
+            'flags': [],
+            'length': 4,
+            'body': None,
+            'WINDOWUPDATE': {
+                'window increment': 512,
+            }
+        }
+
+        assert f.to_json_obj() == result
+
 
 class TestHeadersFrame(object):
     def test_headers_frame_flags(self):

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -120,6 +120,23 @@ class TestDataFrame(object):
         with pytest.raises(ValueError):
             DataFrame(0)
 
+    def test_data_frame_without_padding_diag_serializes_properly(self):
+        f = DataFrame(1)
+        f.flags = set(['END_STREAM'])
+        f.data = b'\x01' * 80
+
+        result = (
+            "DATA\n"
+            "  Stream ID: 1\n"
+            "  Flags: END_STREAM\n"
+            "  Length: 80\n"
+            "  " + "01"*34 + "\n"
+            "  " + "01"*34 + "\n"
+            "  " + "01"*12 + "\n"
+        )
+
+        assert f.diag_serialize() == result
+
 
 class TestPriorityFrame(object):
     payload = b'\x00\x00\x05\x02\x00\x00\x00\x00\x01\x80\x00\x00\x04\x40'

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -365,6 +365,24 @@ class TestPushPromiseFrame(object):
         assert f.promised_stream_id == 4
         assert f.data == b'hello world'
 
+    def test_push_promise_frame_json_serializes_properly(self):
+        f = PushPromiseFrame(1)
+        f.flags = ['END_HEADERS', 'PADDED']
+        f.promised_stream_id = 4
+        f.data = b'\x01\x02\x03\x04'
+        f.pad_length = 10
+        result = {
+            'type': 'PUSHPROMISE',
+            'stream id': 1,
+            'flags': ['END_HEADERS', 'PADDED'],
+            'length': 19,
+            'body': None,
+            'padding length': 11,
+            'PUSH_PROMISE': {'promised stream id': 4}
+        }
+
+        assert f.to_json_obj() == result
+
 
 class TestPingFrame(object):
     def test_ping_frame_has_only_one_flag(self):

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -475,6 +475,26 @@ class TestGoAwayFrame(object):
         assert f.flags == set()
         assert f.additional_data == b'hello'
 
+    def test_goaway_frame_json_serializes_properly(self):
+        f = GoAwayFrame(0)
+        f.last_stream_id = 64
+        f.error_code = 32
+        f.additional_data = b'\x01\x02\x03\x04'
+        result = {
+            'type': 'GOAWAY',
+            'stream id': 0,
+            'flags': [],
+            'length': 12,
+            'body': None,
+            'GOAWAY': {
+                'last stream id': 64,
+                'error code': 32,
+                'additional data': '01020304',
+            }
+        }
+
+        assert f.to_json_obj() == result
+
     def test_goaway_frame_never_has_a_stream(self):
         with pytest.raises(ValueError):
             GoAwayFrame(1)

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -248,6 +248,22 @@ class TestRstStreamFrame(object):
         with pytest.raises(ValueError):
             f.parse_body(b'\x01')
 
+    def test_rst_stream_to_json(self):
+        f = RstStreamFrame(1)
+        f.error_code = 420
+        result = {
+            'type': 'RSTSTREAM',
+            'stream id': 1,
+            'flags': [],
+            'length': 4,
+            'body': None,
+            'RST_STREAM': {
+                'error code': 420,
+            }
+        }
+
+        assert f.to_json_obj() == result
+
 
 class TestSettingsFrame(object):
     serialized = (

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -416,6 +416,20 @@ class TestPingFrame(object):
         assert f.flags == set(['ACK'])
         assert f.opaque_data == b'\x01\x02\x00\x00\x00\x00\x00\x00'
 
+    def test_ping_frame_json_serializes_properly(self):
+        f = PingFrame(0)
+        f.opaque_data = b'\x01\x02\x03\x04'
+        result = {
+            'type': 'PING',
+            'stream id': 0,
+            'flags': [],
+            'length': 8,
+            'body': None,
+            'PING': {'opaque data': '01020304'}
+        }
+
+        assert f.to_json_obj() == result
+
     def test_ping_frame_never_has_a_stream(self):
         with pytest.raises(ValueError):
             PingFrame(1)


### PR DESCRIPTION
Here's an idea out of left field:

Let's ship a command-line tool that can dump a HTTP/2 connection into decoded frames. This would be a useful tool for diagnostic purposes and debugging. In its simplest form it should be able to take a binary file representing the streamed TCP data for a single connection and dump it into the format used by the HTTP/2 specification.

This could, when combined with the SSLSplit tool, make a powerful HTTP/2 diagnostic framework. It'd also show the power of `hyper`'s framing layer.

Other useful features:

- decode HPACK headers on the fly.
- simulate connection state (e.g. flow control windows, stream counts etc.)
- flag protocol violations that don't affect framing
- decode HTTP/2 streams into requests and responses

Getting started on this should be _really_ easy!

##### Proposed output format

```
HEADERS
    {partial header block}

CONTINUATION
  + END_HEADERS
    {partial header block}

{maybe decoded header block here?}

DATA
  + END_STREAM
    {binary data}
```