### PR TITLE
Fxied to call _send_cb() instead of _data_cb() for PingFrame

### DIFF
--- a/hyper/http20/connection.py
+++ b/hyper/http20/connection.py
@@ -339,7 +339,7 @@ class HTTP20Connection(object):
                 p = PingFrame(0)
                 p.flags.add('ACK')
                 p.opaque_data = frame.opaque_data
-                self._data_cb(p, True)
+                self._send_cb(p, True)
         elif frame.type == SettingsFrame.type:
             if 'ACK' not in frame.flags:
                 self._update_settings(frame)

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -1273,7 +1273,7 @@ class TestHyperConnection(object):
 
         def data_cb(frame, tolerate_peer_gone=False):
             assert False, 'should not be called'
-        c._data_cb = data_cb
+        c._send_cb = data_cb
         c.receive_frame(f)
 
     def test_ping_without_ack_gets_reply(self):
@@ -1285,7 +1285,7 @@ class TestHyperConnection(object):
 
         def data_cb(frame, tolerate_peer_gone=False):
             frames.append(frame)
-        c._data_cb = data_cb
+        c._send_cb = data_cb
         c.receive_frame(f)
 
         assert len(frames) == 1


### PR DESCRIPTION
HTTP20Connection object doesn't have `_data_cb()` method. I guess it's a typo? Using _send_cb() works well.

```python
(hyper)$ python
Python 3.4.2 (default, Nov 23 2014, 23:10:23) 
[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.54)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from hyper import HTTP20Connection
>>> conn = HTTP20Connection('google.com')
>>> conn.request('GET', '/')
1
>>> conn.getresponse()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../hyper/http20/connection.py", line 171, in getresponse
    return HTTP20Response(stream.getheaders(), stream)
  File ".../hyper/http20/stream.py", line 293, in getheaders
    self._recv_cb()
  File ".../hyper/http20/connection.py", line 541, in _recv_cb
    self._consume_single_frame()
  File ".../hyper/http20/connection.py", line 521, in _consume_single_frame
    self.receive_frame(frame)
  File ".../hyper/http20/connection.py", line 342, in receive_frame
    self._data_cb(p, True)
AttributeError: 'HTTP20Connection' object has no attribute '_data_cb'
```