### PR TITLE
Adding pep8 and flakes testing

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,5 @@
-include README.rst LICENSE CONTRIBUTORS.rst HISTORY.rst hyper/certs.pem
-
+include CONTRIBUTORS.rst
+include HISTORY.rst
+include LICENSE
+include README.rst
+include hyper/certs.pem

--- a/hyper/__init__.py
+++ b/hyper/__init__.py
@@ -6,18 +6,19 @@ hyper
 A module for providing an abstraction layer over the differences between
 HTTP/1.1 and HTTP/2.
 """
-__version__ = '0.2.0'
+import logging
+import sys as _sys
 
 from .http20.connection import HTTP20Connection
 from .http20.response import HTTP20Response, HTTP20Push
 
+__version__ = '0.2.0'
+
 # Throw import errors on Python <2.7 and 3.0-3.2.
-import sys as _sys
-if _sys.version_info < (2,7) or (3,0) <= _sys.version_info < (3,3):
+if _sys.version_info < (2, 7) or (3, 0) <= _sys.version_info < (3, 3):
     raise ImportError("hyper only supports Python 2.7 and Python 3.3 or higher.")
 
 __all__ = [HTTP20Response, HTTP20Push, HTTP20Connection]
 
 # Set default logging handler.
-import logging
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/hyper/contrib.py
+++ b/hyper/contrib.py
@@ -131,7 +131,6 @@ class HTTP20Adapter(HTTPAdapter):
             def getheaders(self, name):
                 return self.get_all(name, [])
 
-
         response.raw._original_response = orig = FakeOriginalResponse(None)
         orig.version = 20
         orig.status = resp.status

--- a/hyper/http20/connection.py
+++ b/hyper/http20/connection.py
@@ -357,7 +357,7 @@ class HTTP20Connection(object):
             if 'ACK' not in frame.flags:
                 self._update_settings(frame)
 
-                # Need to return an ack.
+                # Need to return an ack.
                 f = SettingsFrame(0)
                 f.flags.add('ACK')
                 self._send_cb(f)
@@ -413,7 +413,7 @@ class HTTP20Connection(object):
         """
         Returns a new stream object for this connection.
         """
-        window_size = self._settings[SettingsFrame.INITIAL_WINDOW_SIZE]
+        window_size = self._settings[SettingsFrame.INITIAL_WINDOW_SIZE] # noqa
         s = Stream(
             stream_id or self.next_stream_id, self._send_cb, self._recv_cb,
             self._close_stream, self.encoder, self.decoder,
@@ -586,7 +586,6 @@ class HTTP20Connection(object):
                 self._consume_single_frame()
             except ConnectionResetError:
                 break
-
 
     # The following two methods are the implementation of the context manager
     # protocol.

--- a/hyper/http20/frame.py
+++ b/hyper/http20/frame.py
@@ -286,7 +286,7 @@ class PushPromiseFrame(Padding, Frame):
     The PUSH_PROMISE frame is used to notify the peer endpoint in advance of
     streams the sender intends to initiate.
     """
-    defined_flags = [('END_HEADERS', 0x04), ('PADDED', 0x08),]
+    defined_flags = [('END_HEADERS', 0x04), ('PADDED', 0x08)]
 
     type = 0x05
 
@@ -460,7 +460,7 @@ class ContinuationFrame(Frame):
 
     stream_association = 'has-stream'
 
-    defined_flags = [('END_HEADERS', 0x04),]
+    defined_flags = [('END_HEADERS', 0x04)]
 
     def serialize_body(self):
         return self.data

--- a/hyper/http20/hpack.py
+++ b/hyper/http20/hpack.py
@@ -13,7 +13,7 @@ import logging
 from ..compat import to_byte
 from .huffman import HuffmanDecoder, HuffmanEncoder
 from hyper.http20.huffman_constants import (
-    REQUEST_CODES, REQUEST_CODES_LENGTH, REQUEST_CODES, REQUEST_CODES_LENGTH
+    REQUEST_CODES, REQUEST_CODES_LENGTH
 )
 from .exceptions import HPACKEncodingError
 
@@ -54,7 +54,9 @@ def decode_integer(data, prefix_bits):
     number of bytes that were consumed from ``data`` in order to get that
     integer.
     """
-    multiple = lambda index: 128 ** (index - 1)
+    def multiple(index):
+        return 128 ** (index - 1)
+
     max_number = (2 ** prefix_bits) - 1
     mask = 0xFF >> (8 - prefix_bits)
     index = 0

--- a/hyper/ssl_compat.py
+++ b/hyper/ssl_compat.py
@@ -247,7 +247,7 @@ class SSLSocket(object):
         def to_components(name):
             # TODO Verify that these are actually *supposed* to all be single-element
             # tuples, and that's not just a quirk of the examples I've seen.
-            return tuple([((resolve_alias(name.decode('utf-8')), value.decode('utf-8')),) for name, value in name.get_components()])
+            return tuple([((resolve_alias(key.decode('utf-8')), value.decode('utf-8')),) for key, value in name.get_components()])
 
         # The standard getpeercert() takes the nice X509 object tree returned
         # by OpenSSL and turns it into a dict according to some format it seems

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,10 @@
+[pytest]
+norecursedirs =
+    build
+
+pep8ignore =
+    *.py E128 E129 E221 E226 E261 E302 E501
+    hyper/http20/huffman_constants.py E131 E241
+
+flakes-ignore =
+    *.py UnusedImport

--- a/setup.py
+++ b/setup.py
@@ -30,9 +30,9 @@ py_version = sys.version_info[:2]
 py_long_version = sys.version_info[:3]
 
 def resolve_install_requires():
-    if py_version == (3,3):
+    if py_version == (3, 3):
         return ['pyOpenSSL>=0.14']
-    elif py_version == (2,7) and py_long_version < (2,7,9):
+    elif py_version == (2, 7) and py_long_version < (2, 7, 9):
         return ['pyOpenSSL>=0.14']
     return []
 

--- a/test/test_hpack_integration.py
+++ b/test/test_hpack_integration.py
@@ -7,7 +7,7 @@ run before every change to HPACK.
 from hyper.http20.hpack import Decoder, Encoder
 from hyper.http20.huffman import HuffmanDecoder, HuffmanEncoder
 from hyper.http20.huffman_constants import (
-    REQUEST_CODES, REQUEST_CODES_LENGTH, REQUEST_CODES, REQUEST_CODES_LENGTH
+    REQUEST_CODES, REQUEST_CODES_LENGTH
 )
 from binascii import unhexlify
 from pytest import skip

--- a/test/test_huffman.py
+++ b/test/test_huffman.py
@@ -1,10 +1,10 @@
 from hyper.http20.huffman import HuffmanDecoder, HuffmanEncoder
-from hyper.http20.huffman_constants import REQUEST_CODES,REQUEST_CODES_LENGTH
+from hyper.http20.huffman_constants import REQUEST_CODES, REQUEST_CODES_LENGTH
 
 
 class TestHuffman(object):
     def test_request_huffman_decoder(self):
-        decoder = HuffmanDecoder(REQUEST_CODES,REQUEST_CODES_LENGTH)
+        decoder = HuffmanDecoder(REQUEST_CODES, REQUEST_CODES_LENGTH)
         assert decoder.decode(b'\xf1\xe3\xc2\xe5\xf2:k\xa0\xab\x90\xf4\xff') == b"www.example.com"
         assert decoder.decode(b'\xa8\xeb\x10d\x9c\xbf') == b"no-cache"
         assert decoder.decode(b'%\xa8I\xe9[\xa9}\x7f') == b"custom-key"
@@ -18,5 +18,5 @@ class TestHuffman(object):
         assert encoder.encode(b"custom-value") == (b'%\xa8I\xe9[\xb8\xe8\xb4\xbf')
 
     def test_eos_terminates_decode_request(self):
-        decoder = HuffmanDecoder(REQUEST_CODES,REQUEST_CODES_LENGTH)
+        decoder = HuffmanDecoder(REQUEST_CODES, REQUEST_CODES_LENGTH)
         assert decoder.decode(b'\xff\xff\xff\xfc') == b''

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -1919,8 +1919,8 @@ class TestResponse(object):
     def test_responses_are_context_managers(self):
         stream = DummyStream('')
 
-        with HTTP20Response([(':status', '200')], stream) as resp:  # noqa
-            pass
+        with HTTP20Response([(':status', '200')], stream) as resp:
+            assert resp
 
         assert stream.closed
 

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -140,7 +140,7 @@ class TestPriorityFrame(object):
         assert f.flags == set()
         assert f.depends_on == 4
         assert f.stream_weight == 64
-        assert f.exclusive == True
+        assert f.exclusive is True
 
     def test_priority_frame_comes_on_a_stream(self):
         with pytest.raises(ValueError):
@@ -408,7 +408,7 @@ class TestHeadersFrame(object):
         assert f.data == b''
         assert f.depends_on == 4
         assert f.stream_weight == 64
-        assert f.exclusive == True
+        assert f.exclusive is True
 
     def test_headers_frame_with_priority_serializes_properly(self):
         # This test also tests that we can receive a HEADERS frame with no
@@ -868,7 +868,6 @@ class TestHPACKDecoder(object):
             (':path', '/',),
             (':authority', 'www.example.com'),
         ]
-        first_header_table = first_header_set[::-1]
         first_data = (
             b'\x82\x86\x84\x01\x8c\xf1\xe3\xc2\xe5\xf2:k\xa0\xab\x90\xf4\xff'
         )
@@ -966,7 +965,7 @@ class TestIntegerDecoding(object):
 class TestHyperConnection(object):
     def test_connections_accept_hosts_and_ports(self):
         c = HTTP20Connection(host='www.google.com', port=8080)
-        assert c.host =='www.google.com'
+        assert c.host == 'www.google.com'
         assert c.port == 8080
 
     def test_connections_can_parse_hosts_and_ports(self):
@@ -1920,7 +1919,7 @@ class TestResponse(object):
     def test_responses_are_context_managers(self):
         stream = DummyStream('')
 
-        with HTTP20Response([(':status', '200')], stream) as resp:
+        with HTTP20Response([(':status', '200')], stream) as resp:  # noqa
             pass
 
         assert stream.closed

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -382,8 +382,9 @@ class TestHyperIntegration(SocketLevelTest):
             # We should get two packets: one connection header string, one
             # SettingsFrame. Rather than respond to the packets, send a GOAWAY
             # frame with error code 0 indicating clean shutdown.
-            first = sock.recv(65535)  # pragma: no flakes
-            second = sock.recv(65535)  # pragma: no flakes
+            first = sock.recv(65535)
+            second = sock.recv(65535)
+            assert first and second
 
             # Now, send the shut down.
             f = GoAwayFrame(0)
@@ -417,8 +418,9 @@ class TestHyperIntegration(SocketLevelTest):
             # We should get two packets: one connection header string, one
             # SettingsFrame. Rather than respond to the packets, send a GOAWAY
             # frame with error code 0 indicating clean shutdown.
-            first = sock.recv(65535)  # pragma: no flakes
-            second = sock.recv(65535)  # pragma: no flakes
+            first = sock.recv(65535)
+            second = sock.recv(65535)
+            assert first and second
 
             # Now, send the shut down.
             f = GoAwayFrame(0)

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -234,7 +234,7 @@ class TestHyperIntegration(SocketLevelTest):
             send_event.wait()
 
         # Check that we closed the connection.
-        assert conn._sock == None
+        assert conn._sock is None
 
         self.tear_down()
 
@@ -382,8 +382,8 @@ class TestHyperIntegration(SocketLevelTest):
             # We should get two packets: one connection header string, one
             # SettingsFrame. Rather than respond to the packets, send a GOAWAY
             # frame with error code 0 indicating clean shutdown.
-            first = sock.recv(65535)
-            second = sock.recv(65535)
+            first = sock.recv(65535)  # pragma: no flakes
+            second = sock.recv(65535)  # pragma: no flakes
 
             # Now, send the shut down.
             f = GoAwayFrame(0)
@@ -417,8 +417,8 @@ class TestHyperIntegration(SocketLevelTest):
             # We should get two packets: one connection header string, one
             # SettingsFrame. Rather than respond to the packets, send a GOAWAY
             # frame with error code 0 indicating clean shutdown.
-            first = sock.recv(65535)
-            second = sock.recv(65535)
+            first = sock.recv(65535)  # pragma: no flakes
+            second = sock.recv(65535)  # pragma: no flakes
 
             # Now, send the shut down.
             f = GoAwayFrame(0)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,6 @@
 pytest
-pytest-xdist
 pytest-cov
+pytest-flakes
+pytest-pep8
+pytest-xdist
 requests

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ envlist = py27, py33, py34, pypy
 
 [testenv]
 deps= -r{toxinidir}/test_requirements.txt
-commands= py.test -n 4 --cov hyper {toxinidir}/test/
+commands= py.test --pep8 --flakes hyper -n 4 --cov hyper {toxinidir}/test/
 
 [testenv:pypy]
 # temporarily disable coverage testing on PyPy due to performance problems
-commands= py.test -n 4 hyper {toxinidir}/test/
+commands= py.test --pep8 --flakes hyper -n 4 hyper {toxinidir}/test/


### PR DESCRIPTION
I found there's no test for coding style. I suggest using pytest plugins as below.

* https://pypi.python.org/pypi/pytest-pep8
* https://pypi.python.org/pypi/pytest-flakes

We can set what pep8/flakes error is in `pytest.ini`. Now I set it as conservative as possible without breaking current coding style. Of course, it is also possible to be strict more.

What do you think?