### PR TITLE
Stop using Twitter for documentation examples (README).

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,8 +15,8 @@ improved speed, lower bandwidth usage, better connection management, and more.
 
     from hyper import HTTP20Connection
 
-    conn = HTTP20Connection('twitter.com:443')
-    conn.request('GET', '/')
+    conn = HTTP20Connection('http2bin.org:443')
+    conn.request('GET', '/get')
     resp = conn.getresponse()
 
     print(resp.read())


### PR DESCRIPTION
Replace *twitter.com:443* with *http2bin.org:443* on the README document.