### PR TITLE
Use http2bin instead of twitter for release test

### DIFF
--- a/test_release.py
+++ b/test_release.py
@@ -56,29 +56,22 @@ class TestHyperActuallyWorks(object):
         assert all(map(lambda p: p.scheme == 'https', pushes))
         assert all(map(lambda p: p.method.lower() == 'get', pushes))
 
-    def test_hitting_twitter(self):
+    def test_hitting_http2bin_org(self):
         """
-        This test function uses the requests adapter and requests to talk to
-        Twitter. We can't use Twython and the API here because I don't want to
-        expose my app keys, and remembering to use environment variables is a
-        pain in the neck.
+        This test function uses the requests adapter and requests to talk to http2bin.
         """
         s = requests.Session()
         a = HTTP20Adapter()
-        s.mount('https://twitter', a)
-        s.mount('https://www.twitter', a)
+        s.mount('http://http2bin', a)
+        s.mount('http://www.http2bin', a)
 
         # Here are some nice URLs.
         urls = [
-            'https://twitter.com/',
-            'https://twitter.com/Lukasaoz',
-            'https://twitter.com/hynek',
-            'https://twitter.com/bitprophet',
-            'https://twitter.com/jessicamckellar',
-            'https://twitter.com/shazow',
-            'https://twitter.com/sigmavirus24',
-            'https://twitter.com/jillysciarilly',
-            'https://twitter.com/kennethreitz',
+            'http://www.http2bin.org/',
+            'http://www.http2bin.org/ip',
+            'http://www.http2bin.org/user-agent',
+	    'http://www.http2bin.org/headers',
+            'http://www.http2bin.org/get',
         ]
 
         # Go get everything.


### PR DESCRIPTION
Update the request adapter test to hit http2bin instead of twitter.
Test was failing with twitter as discussed in #94.