### PR TITLE
ALPN Support

### DIFF
--- a/hyper/ssl_compat.py
+++ b/hyper/ssl_compat.py
@@ -149,6 +149,13 @@ class SSLSocket(object):
 
         return proto if proto else None
 
+    def selected_alpn_protocol(self):
+        proto = self._conn.get_alpn_proto_negotiated()
+        if isinstance(proto, bytes):
+            proto = proto.decode('ascii')
+
+        return proto if proto else None
+
     def getpeercert(self):
         def resolve_alias(alias):
             return dict(
@@ -245,6 +252,10 @@ class SSLContext(object):
                 return b''
 
         self._ctx.set_npn_select_callback(cb)
+
+    def set_alpn_protocols(self, protocols):
+        protocols = list(map(lambda x: x.encode('ascii'), protocols))
+        self._ctx.set_alpn_protos(protocols)
 
     def wrap_socket(self, sock, server_side=False, do_handshake_on_connect=True,
                     suppress_ragged_eofs=True, server_hostname=None):

--- a/hyper/tls.py
+++ b/hyper/tls.py
@@ -11,7 +11,7 @@ from .compat import ignore_missing, ssl
 
 
 NPN_PROTOCOL = 'h2'
-H2_NPN_PROTOCOLS = [NPN_PROTOCOL, 'h2-16', 'h2-15', 'h2-14']  # All h2s we support.
+H2_NPN_PROTOCOLS = [NPN_PROTOCOL, 'h2-16', 'h2-15', 'h2-14']
 SUPPORTED_NPN_PROTOCOLS = H2_NPN_PROTOCOLS + ['http/1.1']
 
 
@@ -21,6 +21,7 @@ _context = None
 
 # Work out where our certificates are.
 cert_loc = path.join(path.dirname(__file__), 'certs.pem')
+
 
 def wrap_socket(sock, server_hostname):
     """
@@ -35,8 +36,8 @@ def wrap_socket(sock, server_hostname):
     # the spec requires SNI support
     ssl_sock = _context.wrap_socket(sock, server_hostname=server_hostname)
     # Setting SSLContext.check_hostname to True only verifies that the
-    # post-handshake servername matches that of the certificate. We also need to
-    # check that it matches the requested one.
+    # post-handshake servername matches that of the certificate. We also need
+    # to check that it matches the requested one.
     if _context.check_hostname:  # pragma: no cover
         try:
             ssl.match_hostname(ssl_sock.getpeercert(), server_hostname)


### PR DESCRIPTION
![](http://i.imgur.com/cydBitc.jpg)

Resolves #31, only 13 months after it was originally opened. In a weird twist of fate, 3.3 will be the first Python version to get ALPN support from hyper.