### PR TITLE
Fix minor spelling errors from the documentation

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -15,7 +15,7 @@ an email. My email address can be found `on my GitHub profile page`_.
 What version of the HTTP/2 specification does ``hyper`` support?
 ----------------------------------------------------------------
 
-``hyper`` suports the final version of the HTTP/2 draft specification. It also
+``hyper`` supports the final version of the HTTP/2 draft specification. It also
 supports versions 14, 15, and 16 of the specification. It supports the final
 version of the HPACK draft specification.
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -5,7 +5,7 @@ Quickstart Guide
 
 First, congratulations on picking ``hyper`` for your HTTP needs. ``hyper``
 is the premier (and, as far as we're aware, the only) Python HTTP/2 library,
-as well as a very servicable HTTP/1.1 library.
+as well as a very serviceable HTTP/1.1 library.
 
 In this section, we'll walk you through using ``hyper``.
 
@@ -80,7 +80,7 @@ Once you've got the data, things diverge a little bit::
     >>> resp.status
     200
 
-If http2bin had compressed the response body. ``hyper`` would automatically
+If http2bin had compressed the response body then ``hyper`` would automatically
 decompress that body for you, no input required. This means you can always get
 the body by simply reading it::
 


### PR DESCRIPTION
Update `faq` and `quickstart` document files