### PR TITLE
Support external SSLContext

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -40,6 +40,11 @@ Headers
 .. autoclass:: hyper.common.headers.HTTPHeaderMap
    :inherited-members:
 
+SSLContext
+----------
+
+.. automethod:: hyper.tls.init_context
+
 Requests Transport Adapter
 --------------------------
 

--- a/hyper/common/connection.py
+++ b/hyper/common/connection.py
@@ -39,6 +39,8 @@ class HTTPConnection(object):
     :param enable_push: (optional) Whether the server is allowed to push
         resources to the client (see
         :meth:`get_pushes() <hyper.HTTP20Connection.get_pushes>`).
+    :param ssl_context: (optional) A class with custom certificate settings.
+        If not provided then hyper's default SSLContext is used instead.
     """
     def __init__(self,
                  host,
@@ -46,13 +48,15 @@ class HTTPConnection(object):
                  secure=None,
                  window_manager=None,
                  enable_push=False,
+                 ssl_context=None,
                  **kwargs):
 
         self._host = host
         self._port = port
-        self._h1_kwargs = {'secure': secure}
+        self._h1_kwargs = {'secure': secure, 'ssl_context': ssl_context}
         self._h2_kwargs = {
-            'window_manager': window_manager, 'enable_push': enable_push
+            'window_manager': window_manager, 'enable_push': enable_push,
+            'ssl_context': ssl_context
         }
 
         # Add any unexpected kwargs to both dictionaries.

--- a/hyper/common/connection.py
+++ b/hyper/common/connection.py
@@ -40,7 +40,7 @@ class HTTPConnection(object):
         resources to the client (see
         :meth:`get_pushes() <hyper.HTTP20Connection.get_pushes>`).
     :param ssl_context: (optional) A class with custom certificate settings.
-        If not provided then hyper's default SSLContext is used instead.
+        If not provided then hyper's default ``SSLContext`` is used instead.
     """
     def __init__(self,
                  host,

--- a/hyper/http11/connection.py
+++ b/hyper/http11/connection.py
@@ -43,8 +43,11 @@ class HTTP11Connection(object):
     :param secure: (optional) Whether the request should use TLS. Defaults to
         ``False`` for most requests, but to ``True`` for any request issued to
         port 443.
+    :param ssl_context: (optional) A class with custom certificate settings.
+        If not provided then hyper's default SSLContext is used instead.
     """
-    def __init__(self, host, port=None, secure=None, **kwargs):
+    def __init__(self, host, port=None, secure=None, ssl_context=None,
+                 **kwargs):
         if port is None:
             try:
                 self.host, self.port = host.split(':')
@@ -64,6 +67,7 @@ class HTTP11Connection(object):
         else:
             self.secure = False
 
+        self.ssl_context = ssl_context
         self._sock = None
 
         #: The size of the in-memory buffer used to store data from the
@@ -88,7 +92,7 @@ class HTTP11Connection(object):
             proto = None
 
             if self.secure:
-                sock, proto = wrap_socket(sock, self.host)
+                sock, proto = wrap_socket(sock, self.host, self.ssl_context)
 
             log.debug("Selected NPN protocol: %s", proto)
             sock = BufferedSocket(sock, self.network_buffer_size)

--- a/hyper/http11/connection.py
+++ b/hyper/http11/connection.py
@@ -44,7 +44,7 @@ class HTTP11Connection(object):
         ``False`` for most requests, but to ``True`` for any request issued to
         port 443.
     :param ssl_context: (optional) A class with custom certificate settings.
-        If not provided then hyper's default SSLContext is used instead.
+        If not provided then hyper's default ``SSLContext`` is used instead.
     """
     def __init__(self, host, port=None, secure=None, ssl_context=None,
                  **kwargs):

--- a/hyper/http20/connection.py
+++ b/hyper/http20/connection.py
@@ -51,10 +51,10 @@ class HTTP20Connection(object):
     :param enable_push: (optional) Whether the server is allowed to push
         resources to the client (see
         :meth:`get_pushes() <hyper.HTTP20Connection.get_pushes>`).
-    :SSLContext: (optional) A class with custom certificate settings. If not provided
+    :ssl_context: (optional) A class with custom certificate settings. If not provided
         then hyper's default SSLContext is used instead.
     """
-    def __init__(self, host, port=None, window_manager=None, enable_push=False, SSLContext=None,
+    def __init__(self, host, port=None, window_manager=None, enable_push=False, ssl_context=None,
                  **kwargs):
         """
         Creates an HTTP/2 connection to a specific server.
@@ -69,7 +69,7 @@ class HTTP20Connection(object):
             self.host, self.port = host, port
 
         self._enable_push = enable_push
-        self._SSLContext = SSLContext
+        self.ssl_context = ssl_context
 
         #: The size of the in-memory buffer used to store data from the
         #: network. This is used as a performance optimisation. Increase buffer
@@ -209,7 +209,7 @@ class HTTP20Connection(object):
         if self._sock is None:
             sock = socket.create_connection((self.host, self.port), 5)
 
-            sock, proto = wrap_socket(sock, self.host, self._SSLContext)
+            sock, proto = wrap_socket(sock, self.host, self.ssl_context)
             log.debug("Selected NPN protocol: %s", proto)
             assert proto in H2_NPN_PROTOCOLS
 

--- a/hyper/http20/connection.py
+++ b/hyper/http20/connection.py
@@ -51,11 +51,11 @@ class HTTP20Connection(object):
     :param enable_push: (optional) Whether the server is allowed to push
         resources to the client (see
         :meth:`get_pushes() <hyper.HTTP20Connection.get_pushes>`).
-    :ssl_context: (optional) A class with custom certificate settings. If not provided
-        then hyper's default SSLContext is used instead.
+    :param ssl_context: (optional) A class with custom certificate settings.
+        If not provided then hyper's default SSLContext is used instead.
     """
-    def __init__(self, host, port=None, window_manager=None, enable_push=False, ssl_context=None,
-                 **kwargs):
+    def __init__(self, host, port=None, window_manager=None, enable_push=False,
+                 ssl_context=None, **kwargs):
         """
         Creates an HTTP/2 connection to a specific server.
         """

--- a/hyper/http20/connection.py
+++ b/hyper/http20/connection.py
@@ -51,8 +51,10 @@ class HTTP20Connection(object):
     :param enable_push: (optional) Whether the server is allowed to push
         resources to the client (see
         :meth:`get_pushes() <hyper.HTTP20Connection.get_pushes>`).
+    :SSLContext: (optional) A class with custom certificate settings. If not provided
+        then hyper's default SSLContext is used instead.
     """
-    def __init__(self, host, port=None, window_manager=None, enable_push=False,
+    def __init__(self, host, port=None, window_manager=None, enable_push=False, SSLContext=None,
                  **kwargs):
         """
         Creates an HTTP/2 connection to a specific server.
@@ -67,6 +69,7 @@ class HTTP20Connection(object):
             self.host, self.port = host, port
 
         self._enable_push = enable_push
+        self._SSLContext = SSLContext
 
         #: The size of the in-memory buffer used to store data from the
         #: network. This is used as a performance optimisation. Increase buffer
@@ -206,7 +209,7 @@ class HTTP20Connection(object):
         if self._sock is None:
             sock = socket.create_connection((self.host, self.port), 5)
 
-            sock, proto = wrap_socket(sock, self.host)
+            sock, proto = wrap_socket(sock, self.host, self._SSLContext)
             log.debug("Selected NPN protocol: %s", proto)
             assert proto in H2_NPN_PROTOCOLS
 

--- a/hyper/http20/connection.py
+++ b/hyper/http20/connection.py
@@ -52,7 +52,7 @@ class HTTP20Connection(object):
         resources to the client (see
         :meth:`get_pushes() <hyper.HTTP20Connection.get_pushes>`).
     :param ssl_context: (optional) A class with custom certificate settings.
-        If not provided then hyper's default SSLContext is used instead.
+        If not provided then hyper's default ``SSLContext`` is used instead.
     """
     def __init__(self, host, port=None, window_manager=None, enable_push=False,
                  ssl_context=None, **kwargs):

--- a/hyper/tls.py
+++ b/hyper/tls.py
@@ -23,7 +23,7 @@ _context = None
 cert_loc = path.join(path.dirname(__file__), 'certs.pem')
 
 
-def wrap_socket(sock, server_hostname, SSLContext=None):
+def wrap_socket(sock, server_hostname, ssl_context=None):
     """
     A vastly simplified SSL wrapping function. We'll probably extend this to
     do more things later.
@@ -31,7 +31,7 @@ def wrap_socket(sock, server_hostname, SSLContext=None):
     global _context
 
     if _context is None:  # pragma: no cover
-        _context = SSLContext or _init_context()
+        _context = ssl_context or _init_context()
 
     # the spec requires SNI support
     ssl_sock = _context.wrap_socket(sock, server_hostname=server_hostname)

--- a/hyper/tls.py
+++ b/hyper/tls.py
@@ -30,6 +30,7 @@ def wrap_socket(sock, server_hostname, ssl_context=None):
     """
     global _context
 
+    # create the singleton SSLContext we use
     if _context is None:  # pragma: no cover
         _context = _init_context()
 
@@ -63,7 +64,7 @@ def wrap_socket(sock, server_hostname, ssl_context=None):
 
 def _init_context():
     """
-    Creates the singleton SSLContext we use.
+    Create a pre-configured SSLContext.
     """
     context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
     context.set_default_verify_paths()

--- a/hyper/tls.py
+++ b/hyper/tls.py
@@ -32,7 +32,7 @@ def wrap_socket(sock, server_hostname, ssl_context=None):
 
     # create the singleton SSLContext we use
     if _context is None:  # pragma: no cover
-        _context = _init_context()
+        _context = init_context()
 
     # if an SSLContext is provided then use it instead of default context
     _ssl_context = ssl_context or _context
@@ -62,13 +62,21 @@ def wrap_socket(sock, server_hostname, ssl_context=None):
     return (ssl_sock, proto)
 
 
-def _init_context():
+def init_context(cert_path=None):
     """
-    Create a pre-configured SSLContext.
+    Create a new ``SSLContext`` that is correctly set up for an HTTP/2 connection.
+    This SSL context object can be customized and passed as a parameter to the
+    :class:`HTTPConnection <hyper.HTTPConnection>` class. Provide your
+    own certificate file in case you don’t want to use hyper’s default
+    certificate. The path to the certificate can be absolute or relative
+    to your working directory.
+
+    :param cert_path: (optional) The path to the certificate file.
+    :returns: An ``SSLContext`` correctly set up for HTTP/2.
     """
     context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
     context.set_default_verify_paths()
-    context.load_verify_locations(cafile=cert_loc)
+    context.load_verify_locations(cafile=cert_path or cert_loc)
     context.verify_mode = ssl.CERT_REQUIRED
     context.check_hostname = True
 

--- a/hyper/tls.py
+++ b/hyper/tls.py
@@ -23,7 +23,7 @@ _context = None
 cert_loc = path.join(path.dirname(__file__), 'certs.pem')
 
 
-def wrap_socket(sock, server_hostname):
+def wrap_socket(sock, server_hostname, SSLContext=None):
     """
     A vastly simplified SSL wrapping function. We'll probably extend this to
     do more things later.
@@ -31,7 +31,7 @@ def wrap_socket(sock, server_hostname):
     global _context
 
     if _context is None:  # pragma: no cover
-        _context = _init_context()
+        _context = SSLContext or _init_context()
 
     # the spec requires SNI support
     ssl_sock = _context.wrap_socket(sock, server_hostname=server_hostname)

--- a/hyper/tls.py
+++ b/hyper/tls.py
@@ -31,10 +31,13 @@ def wrap_socket(sock, server_hostname, ssl_context=None):
     global _context
 
     if _context is None:  # pragma: no cover
-        _context = ssl_context or _init_context()
+        _context = _init_context()
+
+    # if an SSLContext is provided then use it instead of default context
+    _ssl_context = ssl_context or _context
 
     # the spec requires SNI support
-    ssl_sock = _context.wrap_socket(sock, server_hostname=server_hostname)
+    ssl_sock = _ssl_context.wrap_socket(sock, server_hostname=server_hostname)
     # Setting SSLContext.check_hostname to True only verifies that the
     # post-handshake servername matches that of the certificate. We also need
     # to check that it matches the requested one.

--- a/test/test_SSLContext.py
+++ b/test/test_SSLContext.py
@@ -4,7 +4,7 @@ Tests the hyper SSLContext.
 """
 import hyper
 from hyper import HTTP20Connection
-import ssl
+from hyper.compat import ssl
 import pytest
 
 class TestSSLContext(object):
@@ -43,8 +43,8 @@ class TestSSLContext(object):
         context.set_npn_protocols(['h2', 'h2-15'])
         context.options |= ssl.OP_NO_COMPRESSION
         
-        conn = HTTP20Connection('http2bin.org:443', SSLContext=context)
+        conn = HTTP20Connection('http2bin.org:443', ssl_context=context)
         
-        assert conn._SSLContext.check_hostname == True
-        assert conn._SSLContext.verify_mode == ssl.CERT_REQUIRED
-        assert conn._SSLContext.options & ssl.OP_NO_COMPRESSION != 0
+        assert conn.ssl_context.check_hostname == True
+        assert conn.ssl_context.verify_mode == ssl.CERT_REQUIRED
+        assert conn.ssl_context.options & ssl.OP_NO_COMPRESSION != 0

--- a/test/test_SSLContext.py
+++ b/test/test_SSLContext.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""
+Tests the hyper SSLContext.
+"""
+import hyper
+from hyper import HTTP20Connection
+import ssl
+import pytest
+
+class TestSSLContext(object):
+    """
+    Tests default and custom SSLContext
+    """
+    def test_default_context(self):
+        # Create default SSLContext
+        hyper.tls._context = hyper.tls._init_context()
+        assert hyper.tls._context.check_hostname == True
+        assert hyper.tls._context.verify_mode == ssl.CERT_REQUIRED
+        assert hyper.tls._context.options & ssl.OP_NO_COMPRESSION != 0
+
+
+    def test_custom_context(self):
+        # The following SSLContext doesn't provide any valid certicate.
+        # Its purpose is only to confirm that hyper is not using its
+        # default SSLContext.
+        context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+        context.verify_mode = ssl.CERT_NONE
+        context.check_hostname = False
+
+        hyper.tls._context = context
+
+        assert hyper.tls._context.check_hostname == False
+        assert hyper.tls._context.verify_mode == ssl.CERT_NONE
+        assert hyper.tls._context.options & ssl.OP_NO_COMPRESSION == 0
+
+
+    def test_http20Connection_with_custom_context(self):
+        context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+        context.set_default_verify_paths()
+        context.load_verify_locations(cafile='hyper\certs.pem')
+        context.verify_mode = ssl.CERT_REQUIRED
+        context.check_hostname = True
+        context.set_npn_protocols(['h2', 'h2-15'])
+        context.options |= ssl.OP_NO_COMPRESSION
+        
+        conn = HTTP20Connection('http2bin.org:443', SSLContext=context)
+        
+        assert conn._SSLContext.check_hostname == True
+        assert conn._SSLContext.verify_mode == ssl.CERT_REQUIRED
+        assert conn._SSLContext.options & ssl.OP_NO_COMPRESSION != 0

--- a/test/test_SSLContext.py
+++ b/test/test_SSLContext.py
@@ -13,7 +13,7 @@ class TestSSLContext(object):
     """
     def test_default_context(self):
         # Create default SSLContext
-        hyper.tls._context = hyper.tls._init_context()
+        hyper.tls._context = hyper.tls.init_context()
         assert hyper.tls._context.check_hostname == True
         assert hyper.tls._context.verify_mode == ssl.CERT_REQUIRED
         assert hyper.tls._context.options & ssl.OP_NO_COMPRESSION != 0

--- a/test/test_SSLContext.py
+++ b/test/test_SSLContext.py
@@ -3,7 +3,7 @@
 Tests the hyper SSLContext.
 """
 import hyper
-from hyper import HTTP20Connection
+from hyper.common.connection import HTTPConnection
 from hyper.compat import ssl
 import pytest
 
@@ -34,16 +34,16 @@ class TestSSLContext(object):
         assert hyper.tls._context.options & ssl.OP_NO_COMPRESSION == 0
 
 
-    def test_http20Connection_with_custom_context(self):
+    def test_HTTPConnection_with_custom_context(self):
         context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
         context.set_default_verify_paths()
         context.verify_mode = ssl.CERT_REQUIRED
         context.check_hostname = True
         context.set_npn_protocols(['h2', 'h2-15'])
         context.options |= ssl.OP_NO_COMPRESSION
-        
-        conn = HTTP20Connection('http2bin.org:443', ssl_context=context)
-        
+
+        conn = HTTPConnection('http2bin.org', 443, ssl_context=context)
+
         assert conn.ssl_context.check_hostname == True
         assert conn.ssl_context.verify_mode == ssl.CERT_REQUIRED
         assert conn.ssl_context.options & ssl.OP_NO_COMPRESSION != 0

--- a/test/test_SSLContext.py
+++ b/test/test_SSLContext.py
@@ -37,7 +37,6 @@ class TestSSLContext(object):
     def test_http20Connection_with_custom_context(self):
         context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
         context.set_default_verify_paths()
-        context.load_verify_locations(cafile='hyper\certs.pem')
         context.verify_mode = ssl.CERT_REQUIRED
         context.check_hostname = True
         context.set_npn_protocols(['h2', 'h2-15'])

--- a/test/test_abstraction.py
+++ b/test/test_abstraction.py
@@ -8,23 +8,25 @@ class TestHTTPConnection(object):
     def test_h1_kwargs(self):
         c = HTTPConnection(
             'test', 443, secure=False, window_manager=True, enable_push=True,
-            other_kwarg=True
+            ssl_context=False, other_kwarg=True
         )
 
         assert c._h1_kwargs == {
             'secure': False,
+            'ssl_context': False,
             'other_kwarg': True,
         }
 
     def test_h2_kwargs(self):
         c = HTTPConnection(
             'test', 443, secure=False, window_manager=True, enable_push=True,
-            other_kwarg=True
+            ssl_context=True, other_kwarg=True
         )
 
         assert c._h2_kwargs == {
             'window_manager': True,
             'enable_push': True,
+            'ssl_context': True,
             'other_kwarg': True,
         }
 

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -27,7 +27,7 @@ from server import SocketLevelTest
 
 # Turn off certificate verification for the tests.
 if ssl is not None:
-    hyper.tls._context = hyper.tls._init_context()
+    hyper.tls._context = hyper.tls.init_context()
     hyper.tls._context.check_hostname = False
     hyper.tls._context.verify_mode = ssl.CERT_NONE
 

--- a/test/test_integration_http11.py
+++ b/test/test_integration_http11.py
@@ -14,7 +14,7 @@ from server import SocketLevelTest
 
 # Turn off certificate verification for the tests.
 if ssl is not None:
-    hyper.tls._context = hyper.tls._init_context()
+    hyper.tls._context = hyper.tls.init_context()
     hyper.tls._context.check_hostname = False
     hyper.tls._context.verify_mode = ssl.CERT_NONE
 


### PR DESCRIPTION
PR for issue #8

@Lukasa: this is preliminary work, would love to get some feedback on code and unit tests to know if I'm on the right track.

* The `SSLContext` can be assigned to `hyper.tls._context` or passed as an argument to the `HTTP20Connection` constructor. Both cases are covered in the unit test.
* Is it correct to assume that the `SSLContext` argument will later be moved to the `HTTPConnection` abstraction layer?
