### PR TITLE
Close connections gracefully

### DIFF
--- a/hyper/http20/connection.py
+++ b/hyper/http20/connection.py
@@ -558,6 +558,7 @@ class HTTP20Connection(object):
         This builds and handles a frame.
         """
         frame.parse_body(data)
+
         log.info(
             "Received frame %s on stream %d",
             frame.__class__.__name__,

--- a/hyper/http20/connection.py
+++ b/hyper/http20/connection.py
@@ -593,9 +593,8 @@ class HTTP20Connection(object):
                 f = RstStreamFrame(frame.stream_id)
                 f.error_code = 1 # PROTOCOL_ERROR
                 self._send_cb(f)
-                error_string = ("Unexpected stream identifier %d" %
-                                  (frame.stream_id))
-                raise ProtocolError(error_string)
+                log.warning("Unexpected stream identifier %d" %
+                               (frame.stream_id))
         else:
             self.receive_frame(frame)
 

--- a/hyper/http20/connection.py
+++ b/hyper/http20/connection.py
@@ -246,7 +246,12 @@ class HTTP20Connection(object):
             stream.close()
 
         # Send GoAway frame to the server
-        self._send_cb(GoAwayFrame(0), True)
+        try:
+           self._send_cb(GoAwayFrame(0), True)
+        except:
+           log.warn(
+              "GoAway frame could not be sent: %s" % sys.exc_info()[0]
+           )
 
         if self._sock is not None:
             self._sock.close()
@@ -593,8 +598,9 @@ class HTTP20Connection(object):
                 f = RstStreamFrame(frame.stream_id)
                 f.error_code = 1 # PROTOCOL_ERROR
                 self._send_cb(f)
-                log.warning("Unexpected stream identifier %d" %
-                               (frame.stream_id))
+                log.warning(
+                    "Unexpected stream identifier %d" % (frame.stream_id)
+                )
         else:
             self.receive_frame(frame)
 

--- a/hyper/http20/connection.py
+++ b/hyper/http20/connection.py
@@ -247,11 +247,9 @@ class HTTP20Connection(object):
 
         # Send GoAway frame to the server
         try:
-           self._send_cb(GoAwayFrame(0), True)
-        except:
-           log.warn(
-              "GoAway frame could not be sent: %s" % sys.exc_info()[0]
-           )
+            self._send_cb(GoAwayFrame(0), True)
+        except Exception as e:
+            log.warn("GoAway frame could not be sent: %s" % e)
 
         if self._sock is not None:
             self._sock.close()

--- a/hyper/http20/connection.py
+++ b/hyper/http20/connection.py
@@ -18,7 +18,7 @@ from ..packages.hpack.hpack_compat import Encoder, Decoder
 from .stream import Stream
 from .response import HTTP20Response, HTTP20Push
 from .window import FlowControlManager
-from .exceptions import ConnectionError
+from .exceptions import ConnectionError, ProtocolError
 from . import errors
 
 import errno
@@ -558,7 +558,6 @@ class HTTP20Connection(object):
         This builds and handles a frame.
         """
         frame.parse_body(data)
-
         log.info(
             "Received frame %s on stream %d",
             frame.__class__.__name__,
@@ -593,7 +592,9 @@ class HTTP20Connection(object):
                 f = RstStreamFrame(frame.stream_id)
                 f.error_code = 1 # PROTOCOL_ERROR
                 self._send_cb(f)
-                log.warning("Unexpected stream identifier %d", frame.stream_id)
+                error_string = ("Unexpected stream identifier %d" %
+                                  (frame.stream_id))
+                raise ProtocolError(error_string)
         else:
             self.receive_frame(frame)
 

--- a/hyper/http20/errors.py
+++ b/hyper/http20/errors.py
@@ -8,7 +8,7 @@ The registry is based on a 32-bit space so we use the error code to index into
 the array.
 
 The current registry is available at:
-https://tools.ietf.org/html/draft-ietf-httpbis-http2-17#section-11.4
+https://tools.ietf.org/html/rfc7540#section-11.4
 """
 
 NO_ERROR =            {'Name': 'NO_ERROR',

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -1261,6 +1261,21 @@ class TestUtilities(object):
         assert 'data about non existing error code' in err_msg
         assert str(f.error_code) in err_msg
 
+    def test_receive_unexpected_stream_id(self):
+        frames = []
+
+        def data_callback(frame):
+            frames.append(frame)
+
+        c = HTTP20Connection('www.google.com')
+        c._send_cb = data_callback
+
+        f = DataFrame(-1)
+        data = memoryview(b"hi there sir")
+
+        with pytest.raises(ProtocolError):
+            c._consume_frame_payload(f, data)
+
 # Some utility classes for the tests.
 class NullEncoder(object):
     @staticmethod

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -1272,9 +1272,16 @@ class TestUtilities(object):
 
         f = DataFrame(-1)
         data = memoryview(b"hi there sir")
+        c._consume_frame_payload(f, data)
 
-        with pytest.raises(ProtocolError):
-            c._consume_frame_payload(f, data)
+        # If we receive an unexpected stream id then we cancel the stream
+        # by sending a reset stream that contains the protocol error code (1)
+        f = frames[0]
+        assert len(frames) == 1
+        assert f.stream_id == -1
+        assert isinstance(f, RstStreamFrame)
+        assert f.error_code == 1 # PROTOCOL_ERROR
+
 
 # Some utility classes for the tests.
 class NullEncoder(object):

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -1270,7 +1270,7 @@ class TestUtilities(object):
         c = HTTP20Connection('www.google.com')
         c._send_cb = data_callback
 
-        f = DataFrame(-1)
+        f = DataFrame(2)
         data = memoryview(b"hi there sir")
         c._consume_frame_payload(f, data)
 
@@ -1278,7 +1278,7 @@ class TestUtilities(object):
         # by sending a reset stream that contains the protocol error code (1)
         f = frames[0]
         assert len(frames) == 1
-        assert f.stream_id == -1
+        assert f.stream_id == 2
         assert isinstance(f, RstStreamFrame)
         assert f.error_code == 1 # PROTOCOL_ERROR
 


### PR DESCRIPTION
Fix for #15

* When shutting down the connection, close all streams and send a `GoAway` frame to the endpoint.
* If an unexpected stream identifier is received then cancel stream with an error of type `PROTOCOL_ERROR`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/lukasa/hyper/133)
<!-- Reviewable:end -->
