### PR TITLE
Check if length of frame is valid

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,13 @@
 Release History
 ===============
 
+dev
+---
+
+*Software Updates*
+
+- Updated hyperframe to version 1.1.0.
+
 0.4.0 (2015-06-21)
 ------------------
 

--- a/hyper/http20/connection.py
+++ b/hyper/http20/connection.py
@@ -12,7 +12,7 @@ from ..common.headers import HTTPHeaderMap
 from ..packages.hyperframe.frame import (
     FRAMES, DataFrame, HeadersFrame, PushPromiseFrame, RstStreamFrame,
     SettingsFrame, Frame, WindowUpdateFrame, GoAwayFrame, PingFrame,
-    BlockedFrame
+    BlockedFrame, FRAME_MAX_LEN
 )
 from ..packages.hpack.hpack_compat import Encoder, Decoder
 from .stream import Stream
@@ -123,6 +123,7 @@ class HTTP20Connection(object):
         # Values for the settings used on an HTTP/2 connection.
         self._settings = {
             SettingsFrame.INITIAL_WINDOW_SIZE: 65535,
+            SettingsFrame.SETTINGS_MAX_FRAME_SIZE: FRAME_MAX_LEN,
         }
 
         # The socket used to send data.
@@ -469,12 +470,7 @@ class HTTP20Connection(object):
         """
         Called by a stream when it would like to be 'closed'.
         """
-        if error_code is not None:
-            f = RstStreamFrame(stream_id)
-            f.error_code = error_code
-            self._send_cb(f)
-
-        del self.streams[stream_id]
+        self._send_rst_frame(stream_id, error_code)
 
     def _send_cb(self, frame, tolerate_peer_gone=False):
         """
@@ -534,6 +530,16 @@ class HTTP20Connection(object):
 
         # Parse the header. We can use the returned memoryview directly here.
         frame, length = Frame.parse_frame_header(header)
+
+        frame_size = self._settings[SettingsFrame.SETTINGS_MAX_FRAME_SIZE]
+        if (length > frame_size):
+            self._send_rst_frame(frame.stream_id, 6) # 6 = FRAME_SIZE_ERROR
+            log.warning(
+                "Frame size exceeded on stream %d (received: %d, max: %d)",
+                frame.stream_id,
+                length,
+                frame_size
+            )
 
         # Read the remaining data from the socket.
         data = self._recv_payload(length)
@@ -595,9 +601,7 @@ class HTTP20Connection(object):
                 # the ENABLE_PUSH setting is 0, but the spec leaves the client
                 # action undefined when they do it anyway. So we just refuse
                 # the stream and go about our business.
-                f = RstStreamFrame(frame.promised_stream_id)
-                f.error_code = 7 # REFUSED_STREAM
-                self._send_cb(f)
+                self._send_rst_frame(frame.promised_stream_id, 7)
 
         # Work out to whom this frame should go.
         if frame.stream_id != 0:
@@ -606,9 +610,7 @@ class HTTP20Connection(object):
             except KeyError:
                 # If we receive an unexpected stream identifier then we
                 # cancel the stream with an error of type PROTOCOL_ERROR
-                f = RstStreamFrame(frame.stream_id)
-                f.error_code = 1 # PROTOCOL_ERROR
-                self._send_cb(f)
+                self._send_rst_frame(frame.stream_id, 1)
                 log.warning(
                     "Unexpected stream identifier %d" % (frame.stream_id)
                 )
@@ -637,6 +639,21 @@ class HTTP20Connection(object):
             except ConnectionResetError:
                 break
 
+    def _send_rst_frame(self, stream_id, error_code):
+        """
+            Send reset stream frame with error code and remove stream from map.
+        """
+        if error_code is not None:
+            f = RstStreamFrame(stream_id)
+            f.error_code = error_code
+            self._send_cb(f)
+
+        try:
+            del self.streams[stream_id]
+        except KeyError as e:  # pragma: no cover
+            log.warn(
+                "Stream with id %d does not exist: %s",
+                stream_id, e)
 
     # The following two methods are the implementation of the context manager
     # protocol.

--- a/hyper/http20/connection.py
+++ b/hyper/http20/connection.py
@@ -12,7 +12,7 @@ from ..common.headers import HTTPHeaderMap
 from ..packages.hyperframe.frame import (
     FRAMES, DataFrame, HeadersFrame, PushPromiseFrame, RstStreamFrame,
     SettingsFrame, Frame, WindowUpdateFrame, GoAwayFrame, PingFrame,
-    BlockedFrame, FRAME_MAX_LEN
+    BlockedFrame, FRAME_MAX_LEN, FRAME_MAX_ALLOWED_LEN
 )
 from ..packages.hpack.hpack_compat import Encoder, Decoder
 from .stream import Stream
@@ -449,6 +449,11 @@ class HTTP20Connection(object):
             self._out_flow_control_window += delta
 
             self._settings[SettingsFrame.INITIAL_WINDOW_SIZE] = newsize
+
+        if SettingsFrame.SETTINGS_MAX_FRAME_SIZE in frame.settings:
+            new_size = frame.settings[SettingsFrame.SETTINGS_MAX_FRAME_SIZE]
+            if new_size > FRAME_MAX_LEN and new_size < FRAME_MAX_ALLOWED_LEN:
+                self._settings[SettingsFrame.SETTINGS_MAX_FRAME_SIZE] = new_size
 
     def _new_stream(self, stream_id=None, local_closed=False):
         """

--- a/hyper/http20/connection.py
+++ b/hyper/http20/connection.py
@@ -510,8 +510,12 @@ class HTTP20Connection(object):
 
         data = frame.serialize()
 
-        if frame.body_len > FRAME_MAX_LEN:  # pragma: no cover
-            raise ValueError("Frame size %d is too large" % frame.body_len)
+        if frame.body_len > self._settings[SettingsFrame.SETTINGS_MAX_FRAME_SIZE]:
+            raise ValueError(
+                     "Frame size %d exceeds maximum frame size setting %d" %
+                     (frame.body_len,
+                     self._settings[SettingsFrame.SETTINGS_MAX_FRAME_SIZE])
+            )
 
         log.info(
             "Sending frame %s on stream %d",

--- a/hyper/http20/stream.py
+++ b/hyper/http20/stream.py
@@ -368,8 +368,9 @@ class Stream(object):
         :returns: Nothing.
         """
         # Right now let's not bother with grace, let's just call close on the
-        # connection.
-        self._close_cb(self.stream_id, error_code)
+        # connection. If not error code is provided then assume it is a
+        # gracefull shutdown.
+        self._close_cb(self.stream_id, error_code or 0)
 
     def _handle_header_block(self, headers):
         """

--- a/hyper/packages/hyperframe/__init__.py
+++ b/hyper/packages/hyperframe/__init__.py
@@ -5,4 +5,4 @@ hyperframe
 
 A module for providing a pure-Python HTTP/2 framing layer.
 """
-__version__ = '1.0.0'
+__version__ = '1.1.0'

--- a/hyper/packages/hyperframe/frame.py
+++ b/hyper/packages/hyperframe/frame.py
@@ -10,10 +10,10 @@ socket.
 import collections
 import struct
 
-# The maximum initial length of a frame. Some frames have shorter maximum lengths.
+# The maximum initial lengh of a frame. Some frames have shorter maximum lengths.
 FRAME_MAX_LEN = (2 ** 14) - 1
 
-# The maximum allowed length of a frame.
+# The maximum allowed lengh of a frame.
 FRAME_MAX_ALLOWED_LEN = (2 ** 24) - 1
 
 class Frame(object):

--- a/hyper/packages/hyperframe/frame.py
+++ b/hyper/packages/hyperframe/frame.py
@@ -10,10 +10,10 @@ socket.
 import collections
 import struct
 
-# The maximum initial lengh of a frame. Some frames have shorter maximum lengths.
+# The maximum initial length of a frame. Some frames have shorter maximum lengths.
 FRAME_MAX_LEN = (2 ** 14) - 1
 
-# The maximum allowed lengh of a frame.
+# The maximum allowed length of a frame.
 FRAME_MAX_ALLOWED_LEN = (2 ** 24) - 1
 
 class Frame(object):

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -1351,9 +1351,12 @@ class TestUtilities(object):
     def test_connection_sends_rst_frame_if_frame_size_too_large(self):
         sock = DummySocket()
         d = DataFrame(1)
-        # Create big data frame that exceeds the FRAME_MAX_LEN value in order
-        # to trigger the reset frame with error code 6 (FRAME_SIZE_ERROR)
-        d.data = b''.join([b"hi there sir" for x in range(40)])
+        # Receive oversized frame on the client side.
+        # Create huge data frame that exceeds the FRAME_MAX_LEN value in order
+        # to trigger the reset frame with error code 6 (FRAME_SIZE_ERROR).
+        # FRAME_MAX_LEN is a constant value for the hyper client and cannot 
+        # be updated as of now.
+        d.data = b''.join([b"hi there client" for x in range(40)])
         sock.buffer = BytesIO(d.serialize())
 
         frames = []
@@ -1375,7 +1378,7 @@ class TestUtilities(object):
         assert f.stream_id == 1
         assert f.error_code == 6 #FRAME_SIZE_ERROR
 
-    def test_connection_stream_is_removed_on_frame_size_error(self):
+    def test_connection_stream_is_removed_when_receiving_out_of_range_frame(self):
         sock = DummySocket()
         d = DataFrame(1)
         d.data = b''.join([b"hi there sir" for x in range(40)])
@@ -1390,6 +1393,20 @@ class TestUtilities(object):
         assert len(c.streams) == 1
         c._recv_cb()
         assert len(c.streams) == 0
+
+    def test_connection_error_when_send_out_of_range_frame(self):
+        # Send oversized frame to the server side.
+        # Create huge data frame that exceeds the intitial FRAME_MAX_LEN setting
+        # in order to trigger a value error when sending it.
+        # Note that the value of the FRAME_MAX_LEN setting can be updated
+        # by the server through a settings frame.
+        d = DataFrame(1)
+        d.data = b''.join([b"hi there server" for x in range(1500)])
+
+        c = HTTP20Connection('www.google.com')
+        c._sock = DummySocket()
+        with pytest.raises(ValueError):
+            c._send_cb(d)
 
 # Some utility classes for the tests.
 class NullEncoder(object):

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -1356,7 +1356,7 @@ class TestUtilities(object):
         # to trigger the reset frame with error code 6 (FRAME_SIZE_ERROR).
         # FRAME_MAX_LEN is a constant value for the hyper client and cannot 
         # be updated as of now.
-        d.data = b''.join([b"hi there client" for x in range(40)])
+        d.data = b''.join([b"hi there client" for x in range(1500)])
         sock.buffer = BytesIO(d.serialize())
 
         frames = []
@@ -1381,7 +1381,7 @@ class TestUtilities(object):
     def test_connection_stream_is_removed_when_receiving_out_of_range_frame(self):
         sock = DummySocket()
         d = DataFrame(1)
-        d.data = b''.join([b"hi there sir" for x in range(40)])
+        d.data = b''.join([b"hi there sir" for x in range(1500)])
         sock.buffer = BytesIO(d.serialize())
 
         c = HTTP20Connection('www.google.com')

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -273,7 +273,8 @@ class TestHyperConnection(object):
         c._sock = sock
 
         # 'Receive' the SETTINGS frame.
-        c.receive_frame(f)
+        with pytest.raises(ConnectionError):
+            c.receive_frame(f)
 
         # The value advertised by an endpoint MUST be between 2^14 and
         # 2^24-1 octets. Confirm that the max frame size did not increase.
@@ -282,6 +283,10 @@ class TestHyperConnection(object):
         # When the setting containing the max frame size value is out of range,
         # the spec dictates to tear down the connection.
         assert c._sock == None
+
+        # Check if GoAway frame was correctly sent to the endpoint
+        f = decode_frame(sock.queue[0])
+        assert isinstance(f, GoAwayFrame)
 
     def test_connections_handle_too_big_max_frame_size_properly(self):
         sock = DummySocket()
@@ -291,7 +296,8 @@ class TestHyperConnection(object):
         c._sock = sock
 
         # 'Receive' the SETTINGS frame.
-        c.receive_frame(f)
+        with pytest.raises(ConnectionError):
+            c.receive_frame(f)
 
         # The value advertised by an endpoint MUST be between 2^14 and
         # 2^24-1 octets. Confirm that the max frame size did not increase.
@@ -300,6 +306,10 @@ class TestHyperConnection(object):
         # When the setting containing the max frame size value is out of range,
         # the spec dictates to tear down the connection.
         assert c._sock == None
+
+        # Check if GoAway frame was correctly sent to the endpoint
+        f = decode_frame(sock.queue[0])
+        assert isinstance(f, GoAwayFrame)
 
     def test_connections_handle_resizing_header_tables_properly(self):
         sock = DummySocket()


### PR DESCRIPTION
Fix for #69 

* Before processing a frame, check if its length is valid using the range defined by the [spec](https://http2.github.io/http2-spec/#SETTINGS_MAX_FRAME_SIZE). 
* Allow endpoint to update the max frame size setting.