### PR TITLE
Use check_hostname of _ssl_context

### DIFF
--- a/hyper/tls.py
+++ b/hyper/tls.py
@@ -43,7 +43,7 @@ def wrap_socket(sock, server_hostname, ssl_context=None):
     # Setting SSLContext.check_hostname to True only verifies that the
     # post-handshake servername matches that of the certificate. We also need
     # to check that it matches the requested one.
-    if _context.check_hostname:  # pragma: no cover
+    if _ssl_context.check_hostname:  # pragma: no cover
         try:
             ssl.match_hostname(ssl_sock.getpeercert(), server_hostname)
         except AttributeError:


### PR DESCRIPTION
It looks like that current implementation always refer `check_hostname` of global `_context`.
This ignore `check_hostname` of external SSLContext if it is given.