### PR TITLE
nahpackpy HPACK implementation supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - TEST_RELEASE=false HYPER_FAST_PARSE=true
   - TEST_RELEASE=true HYPER_FAST_PARSE=false
   - TEST_RELEASE=true HYPER_FAST_PARSE=true
+  - NAHPACKPY=true
   - NGHTTP2=true
 
 matrix:

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -37,6 +37,12 @@ if [[ "$NGHTTP2" = true ]]; then
     # Let's try ldconfig.
     sudo sh -c 'echo "/usr/local/lib" > /etc/ld.so.conf.d/libnghttp2.conf'
     sudo ldconfig
+elif [[ $NAHPACKPY == true ]]; then
+    # compile rust nightly for nahpackpy build
+    wget http://static.rust-lang.org/dist/rust-nightly-x86_64-unknown-linux-gnu.tar.gz  # wget exit 4 with TLS
+    tar xvfz rust-nightly-x86_64-unknown-linux-gnu.tar.gz
+    cd rust-nightly-x86_64-unknown-linux-gnu && sudo ./install.sh && cd ..
+    pip install "nahpackpy>=0.1.0,<0.2.0"
 fi
 
 if [[ "$HYPER_FAST_PARSE" = true ]]; then

--- a/hyper/packages/hpack/__init__.py
+++ b/hyper/packages/hpack/__init__.py
@@ -5,4 +5,15 @@ hpack
 
 HTTP/2 header encoding for Python.
 """
+
+from .hpack_compat import Encoder, Decoder
+
+
+__all__ = (
+    'Encoder',
+    'Decoder',
+    '__version__',
+)
+
+
 __version__ = '1.0.1'

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,6 @@ setup(
         ],
     },
     extras_require={
-        'fast': ['pycohttpparser'],
+        'fast': ['pycohttpparser', 'nahpackpy'],
     }
 )


### PR DESCRIPTION
This pull request adds support for using https://github.com/ijl/nahpackpy for HPACK. 

It's faster than the pure Python lib due to being a wrapper around a Rust library and is perhaps a little more convenient than nghttp2 for being installable via PyPI so long as rust nightly is present. It's at 100% coverage: https://travis-ci.org/ijl/nahpackpy.

I've added it as an extra on `pip install hyper[fast]`.

Decoding and encoding benchmarks of nahpackpy and the pure Python hpack for `hpack-test-case/nghttp2/story_31.json`, case 0, on CPython 3.4.3:

```python
>>> from binascii import unhexlify
>>> from hyper.packages.hpack.hpack import Decoder as PyDecoder
>>> from hyper.packages.hpack.hpack_compat import Decoder as NahpackDecoder
>>> to_decode = unhexlify('0f0d826c424090f2b10f524b52564faacab1eb498f523f85a8e8a8d2cb886496df697e941054d03f4a08016540bf702f5c65953168df4087f2b12a291263d5842507417f6c96df3dbf4a044a435d8a0801128066e019b820298b46ff408721eaa8a4498f5788ea52d6b0e83772ff5892aed8e8313e94a47e561cc5802e882e3ce3ff6196dc34fd280654d27eea0801128115c6c171a694c5a37f54012a5f87352398ac4c697f4088f2b4b1ad2163b66fa4c9c4ac6ef16932db7519d3c71f2cbe05af449ab7eaf36e0e5c0d63669b669df3f5df341f')
>>> timeit PyDecoder().decode(to_decode)
1000 loops, best of 3: 1.1 ms per loop
>>> timeit NahpackDecoder().decode(to_decode)
10000 loops, best of 3: 27.4 µs per loop
```

```python
>>> from hyper.packages.hpack.hpack import Encoder as PyEncoder
>>> from hyper.packages.hpack.hpack_compat import Encoder as NahpackEncoder
>>> to_encode = ((b"content-length",b"522"),(b"x-content-type-options",b"nosniff"),(b",status",b"200"),(b"expires",b"Tue,21 May 2013 19,18,33 GMT"),(b"x-cnection",b"close"),(b"last-modified",b"Thu,12 Apr 2012 03,03,20 GMT"),(b"connection",b"keep-alive"),(b"cache-control",b"public,max-age=17216869"),(b"date",b"Sat,03 Nov 2012 12,50,44 GMT"),(b"access-control-allow-origin",b"*"),(b"content-type",b"image/gif"),(b"x-fb-debug",b"IVe/SwucJuBsLtVHWJw2PMdOTOxuEWUir5igQNThkTg="))
>>> timeit PyEncoder().encode(to_encode)
1000 loops, best of 3: 258 µs per loop
>>> timeit NahpackEncoder().encode(to_encode)
10000 loops, best of 3: 34.7 µs per loop
```

I suppose pypy will fail on Travis due to the SSL issue affecting other pull requests.