### PR TITLE
Include tox.ini in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include README.rst LICENSE CONTRIBUTORS.rst HISTORY.rst hyper/certs.pem
+include README.rst LICENSE CONTRIBUTORS.rst HISTORY.rst hyper/certs.pem tox.ini
 


### PR DESCRIPTION
Allows downstream consumers and OS packagers & porters to use tox for testing since py.test by itself doesn't work without hyper being installed in site-packages. Fixing the latter would be much preferable than having to run tox.

Supporting the setup.py test command and having tests *just work* via that method (read tests_require, test_suite) would also be great but is out of scope for this change:

[Pytest: Integration with setuptools test commands](https://pytest.org/latest/goodpractises.html#integration-with-setuptools-test-commands)