### PR TITLE
Allow non-dictionary header arguments in request method.

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -38,3 +38,7 @@ In chronological order:
   - Added support for upgrade of plaintext HTTP/1.1 to plaintext HTTP/2.
   - Added proxy support.
   - Improved IPv6 support.
+
+- Eugene Obukhov (@irvind)
+
+  - General code improvements.

--- a/hyper/http11/connection.py
+++ b/hyper/http11/connection.py
@@ -10,6 +10,8 @@ import os
 import socket
 import base64
 
+from collections import Iterable
+
 from .response import HTTP11Response
 from ..tls import wrap_socket, H2C_PROTOCOL
 from ..common.bufsocket import BufferedSocket
@@ -148,7 +150,9 @@ class HTTP11Connection(object):
         url = to_bytestring(url)
 
         if not isinstance(headers, HTTPHeaderMap):
-            # FIXME: Handle things that aren't dictionaries here.
+            if isinstance(headers, Iterable):
+                headers = dict(headers)
+
             headers = HTTPHeaderMap(headers.items())
 
         if self._sock is None:

--- a/hyper/http11/connection.py
+++ b/hyper/http11/connection.py
@@ -10,7 +10,7 @@ import os
 import socket
 import base64
 
-from collections import Iterable
+from collections import Iterable, Mapping
 
 from .response import HTTP11Response
 from ..tls import wrap_socket, H2C_PROTOCOL
@@ -150,10 +150,12 @@ class HTTP11Connection(object):
         url = to_bytestring(url)
 
         if not isinstance(headers, HTTPHeaderMap):
-            if isinstance(headers, Iterable):
-                headers = dict(headers)
-
-            headers = HTTPHeaderMap(headers.items())
+            if isinstance(headers, Mapping):
+                headers = HTTPHeaderMap(headers.items())
+            elif isinstance(headers, Iterable):
+                headers = HTTPHeaderMap(headers)
+            else:
+                raise ValueError('Header argument must be a dictionary or an iterable')
 
         if self._sock is None:
             self.connect()

--- a/test/test_http11.py
+++ b/test/test_http11.py
@@ -132,6 +132,7 @@ class TestHTTP11Connection(object):
             ('User-Agent', 'hyper'), 
             ('Custom-field', 'test'),
             ('Custom-field2', 'test'),
+            ('Custom-field', 'test2'),
         ))
         
         expected = (
@@ -139,6 +140,7 @@ class TestHTTP11Connection(object):
             b"User-Agent: hyper\r\n"
             b"Custom-field: test\r\n"
             b"Custom-field2: test\r\n"
+            b"Custom-field: test2\r\n"
             b"connection: Upgrade, HTTP2-Settings\r\n"
             b"upgrade: h2c\r\n"
             b"HTTP2-Settings: AAQAAP//\r\n"

--- a/test/test_http11.py
+++ b/test/test_http11.py
@@ -124,15 +124,21 @@ class TestHTTP11Connection(object):
 
         assert received == expected
 
-    def test_iterable_headers(self):
+    def test_iterable_header(self):
         c = HTTP11Connection('httpbin.org')
         c._sock = sock = DummySocket()
 
-        c.request('GET', '/get', headers=(('User-Agent', 'hyper'),))
+        c.request('GET', '/get', headers=(
+            ('User-Agent', 'hyper'), 
+            ('Custom-field', 'test'),
+            ('Custom-field2', 'test'),
+        ))
         
         expected = (
             b"GET /get HTTP/1.1\r\n"
             b"User-Agent: hyper\r\n"
+            b"Custom-field: test\r\n"
+            b"Custom-field2: test\r\n"
             b"connection: Upgrade, HTTP2-Settings\r\n"
             b"upgrade: h2c\r\n"
             b"HTTP2-Settings: AAQAAP//\r\n"
@@ -142,6 +148,13 @@ class TestHTTP11Connection(object):
         received = b''.join(sock.queue)
 
         assert received == expected
+
+    def test_invalid_header(self):
+        c = HTTP11Connection('httpbin.org')
+        c._sock = sock = DummySocket()
+
+        with pytest.raises(ValueError):
+            c.request('GET', '/get', headers=42)
 
     def test_proxy_request(self):
         c = HTTP11Connection('httpbin.org', proxy_host='localhost')

--- a/test/test_http11.py
+++ b/test/test_http11.py
@@ -124,6 +124,25 @@ class TestHTTP11Connection(object):
 
         assert received == expected
 
+    def test_iterable_headers(self):
+        c = HTTP11Connection('httpbin.org')
+        c._sock = sock = DummySocket()
+
+        c.request('GET', '/get', headers=(('User-Agent', 'hyper'),))
+        
+        expected = (
+            b"GET /get HTTP/1.1\r\n"
+            b"User-Agent: hyper\r\n"
+            b"connection: Upgrade, HTTP2-Settings\r\n"
+            b"upgrade: h2c\r\n"
+            b"HTTP2-Settings: AAQAAP//\r\n"
+            b"host: httpbin.org\r\n"
+            b"\r\n"
+        )
+        received = b''.join(sock.queue)
+
+        assert received == expected
+
     def test_proxy_request(self):
         c = HTTP11Connection('httpbin.org', proxy_host='localhost')
         c._sock = sock = DummySocket()


### PR DESCRIPTION
It's just a tiny improvement for HTTP11Connection class. Now you can pass any iterable as a header argument. 