### PR TITLE
Use memoryview when decoding HPACK headers

### DIFF
--- a/hyper/packages/hpack/hpack.py
+++ b/hyper/packages/hpack/hpack.py
@@ -500,6 +500,7 @@ class Decoder(object):
         """
         log.debug("Decoding %s", data)
 
+        data_mem = memoryview(data)
         headers = []
         data_len = len(data)
         current_index = 0
@@ -519,20 +520,20 @@ class Decoder(object):
             encoding_update = bool(current & 0x20)
 
             if indexed:
-                header, consumed = self._decode_indexed(data[current_index:])
+                header, consumed = self._decode_indexed(data_mem[current_index:])
             elif literal_index:
                 # It's a literal header that does affect the header table.
                 header, consumed = self._decode_literal_index(
-                    data[current_index:]
+                    data_mem[current_index:]
                 )
             elif encoding_update:
                 # It's an update to the encoding context.
-                consumed = self._update_encoding_context(data)
+                consumed = self._update_encoding_context(data_mem)
                 header = None
             else:
                 # It's a literal header that does not affect the header table.
                 header, consumed = self._decode_literal_no_index(
-                    data[current_index:]
+                    data_mem[current_index:]
                 )
 
             if header:


### PR DESCRIPTION
In this pull request I was trying to resolve the issue #61. Tests passed successfully for py3.4 and py2.7 on my machine, but unfortunately, I don't know if it's gonna work for PyPy.