### PR TITLE
Add support of AppEngine SSL library

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 Cory Benfield
+Copyright (c) 2014 Cory Benfield, Google Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/hyper/compat.py
+++ b/hyper/compat.py
@@ -36,11 +36,11 @@ def ignore_missing():
         pass
 
 if is_py2:
-    if is_py2_7_9_or_later:
-        import ssl
-    elif is_appengine:
+    if is_appengine:
         from . import ssl_compat_appengine
         ssl = ssl_compat_appengine
+    elif is_py2_7_9_or_later:
+        import ssl
     else:
         ssl = ssl_compat
 

--- a/hyper/compat.py
+++ b/hyper/compat.py
@@ -15,11 +15,18 @@ except ImportError:
     # TODO log?
     ssl_compat = None
 
+try:
+    import google.appengine
+    is_appengine = True
+except ImportError:
+    is_appengine = False
+
 _ver = sys.version_info
 is_py2 = _ver[0] == 2
 is_py2_7_9_or_later = _ver[0] >= 2 and _ver[1] >= 7 and _ver[2] >= 9
 is_py3 = _ver[0] == 3
 is_py3_3 = is_py3 and _ver[1] == 3
+
 
 @contextmanager
 def ignore_missing():
@@ -31,6 +38,9 @@ def ignore_missing():
 if is_py2:
     if is_py2_7_9_or_later:
         import ssl
+    elif is_appengine:
+        from . import ssl_compat_appengine
+        ssl = ssl_compat_appengine
     else:
         ssl = ssl_compat
 

--- a/hyper/http20/connection.py
+++ b/hyper/http20/connection.py
@@ -10,6 +10,7 @@ from ..common.exceptions import ConnectionResetError
 from ..common.bufsocket import BufferedSocket
 from ..common.headers import HTTPHeaderMap
 from ..common.util import to_host_port_tuple, to_native_string
+from ..compat import is_appengine
 from ..packages.hyperframe.frame import (
     FRAMES, DataFrame, HeadersFrame, PushPromiseFrame, RstStreamFrame,
     SettingsFrame, Frame, WindowUpdateFrame, GoAwayFrame, PingFrame,
@@ -254,7 +255,10 @@ class HTTP20Connection(object):
                 proto = H2C_PROTOCOL
 
             log.debug("Selected NPN protocol: %s", proto)
-            assert proto in H2_NPN_PROTOCOLS or proto == H2C_PROTOCOL
+            # AppEngine SSLSocket does not have selected_npn_protocol nor
+            # selected_alpn_protocol, so just avoid this assertion.
+            assert is_appengine or (
+                proto in H2_NPN_PROTOCOLS or proto == H2C_PROTOCOL)
 
             self._sock = BufferedSocket(sock, self.network_buffer_size)
 

--- a/hyper/http20/connection.py
+++ b/hyper/http20/connection.py
@@ -10,7 +10,6 @@ from ..common.exceptions import ConnectionResetError
 from ..common.bufsocket import BufferedSocket
 from ..common.headers import HTTPHeaderMap
 from ..common.util import to_host_port_tuple, to_native_string
-from ..compat import is_appengine
 from ..packages.hyperframe.frame import (
     FRAMES, DataFrame, HeadersFrame, PushPromiseFrame, RstStreamFrame,
     SettingsFrame, Frame, WindowUpdateFrame, GoAwayFrame, PingFrame,
@@ -255,10 +254,7 @@ class HTTP20Connection(object):
                 proto = H2C_PROTOCOL
 
             log.debug("Selected NPN protocol: %s", proto)
-            # AppEngine SSLSocket does not have selected_npn_protocol nor
-            # selected_alpn_protocol, so just avoid this assertion.
-            assert is_appengine or (
-                proto in H2_NPN_PROTOCOLS or proto == H2C_PROTOCOL)
+            assert proto in H2_NPN_PROTOCOLS or proto == H2C_PROTOCOL
 
             self._sock = BufferedSocket(sock, self.network_buffer_size)
 

--- a/hyper/ssl_compat_appengine.py
+++ b/hyper/ssl_compat_appengine.py
@@ -19,7 +19,7 @@ from ssl import match_hostname
 OP_NO_COMPRESSION = 0
 
 
-class SSLContext:
+class SSLContext(object):
     """A SSL context which implements the methods used by hyper."""
 
     def __init__(self, proto):
@@ -38,12 +38,8 @@ class SSLContext:
 
     def wrap_socket(self, sock, server_side=False, do_handshake_on_connect=True,
                     suppress_ragged_eofs=True, server_hostname=None):
-        sock = ssl.wrap_socket(
+        return ssl.wrap_socket(
             sock, server_side=server_side, cert_reqs=self.verify_mode,
             ssl_version=self.protocol_version, ca_certs=self.custom_ca_cert,
             suppress_ragged_eofs=suppress_ragged_eofs,
             do_handshake_on_connect=do_handshake_on_connect)
-        # AppEngine SSLSocket does not have selected_npn_protocol, a hacky
-        # solution to return a dummy data.
-        sock.selected_npn_protocol = lambda: 'h2c'
-        return sock

--- a/hyper/ssl_compat_appengine.py
+++ b/hyper/ssl_compat_appengine.py
@@ -38,8 +38,12 @@ class SSLContext(object):
 
     def wrap_socket(self, sock, server_side=False, do_handshake_on_connect=True,
                     suppress_ragged_eofs=True, server_hostname=None):
-        return ssl.wrap_socket(
+        sock = ssl.wrap_socket(
             sock, server_side=server_side, cert_reqs=self.verify_mode,
             ssl_version=self.protocol_version, ca_certs=self.custom_ca_cert,
             suppress_ragged_eofs=suppress_ragged_eofs,
             do_handshake_on_connect=do_handshake_on_connect)
+        # AppEngine SSLSocket does not have selected_npn_protocol, a hacky
+        # solution to return a dummy data.
+        sock.selected_npn_protocol = lambda: 'h2'
+        return sock

--- a/hyper/ssl_compat_appengine.py
+++ b/hyper/ssl_compat_appengine.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""
+hyper/ssl_compat_appengine
+~~~~~~~~~
+
+Provides the ssl module interface which hyper assumes, based on AppEngine ssl.
+
+This module complements some constants and classes which don't exist on
+AppEngine's SSL module, to be used by hyper smoothly.
+See: https://cloud.google.com/appengine/docs/python/sockets/ssl_support
+"""
+
+import ssl
+
+from ssl import PROTOCOL_TLSv1, PROTOCOL_SSLv23, PROTOCOL_SSLv3
+from ssl import CERT_NONE, CERT_OPTIONAL, CERT_REQUIRED
+from ssl import match_hostname
+
+OP_NO_COMPRESSION = 0
+
+
+class SSLContext:
+    """A SSL context which implements the methods used by hyper."""
+
+    def __init__(self, proto):
+        self.protocol_version = proto
+        self.verify_mode = CERT_REQUIRED
+        self.check_hostname = True
+        self.options = 0
+        self.custom_ca_cert = None
+
+    def set_default_verify_paths(self):
+        # Intentionally do nothing.
+        pass
+
+    def load_verify_locations(self, cafile):
+        self.custom_ca_cert = cafile
+
+    def wrap_socket(self, sock, server_side=False, do_handshake_on_connect=True,
+                    suppress_ragged_eofs=True, server_hostname=None):
+        sock = ssl.wrap_socket(
+            sock, server_side=server_side, cert_reqs=self.verify_mode,
+            ssl_version=self.protocol_version, ca_certs=self.custom_ca_cert,
+            suppress_ragged_eofs=suppress_ragged_eofs,
+            do_handshake_on_connect=do_handshake_on_connect)
+        # AppEngine SSLSocket does not have selected_npn_protocol, a hacky
+        # solution to return a dummy data.
+        sock.selected_npn_protocol = lambda: 'h2c'
+        return sock

--- a/test/test_appengine.py
+++ b/test/test_appengine.py
@@ -40,6 +40,7 @@ class TestAppengineSocket(SocketLevelTest):
 
     def socket_handler(self, listener):
         sock = listener.accept()[0]
+        sock.do_handshake()
         sock.close()
 
     def test_wrap_socket(self):
@@ -54,7 +55,7 @@ class TestAppengineSocket(SocketLevelTest):
         context.load_verify_locations('test/certs/server.crt')
         sock = socket.create_connection(
             (self.server_thread.host, self.server_thread.port))
-        ssl_sock = context.wrap_socket(sock, do_handshake_on_connect=False)
+        ssl_sock = context.wrap_socket(sock)
         assert ssl_sock.selected_npn_protocol() == 'h2'
         ssl_sock.close()
         self.tear_down()

--- a/test/test_appengine.py
+++ b/test/test_appengine.py
@@ -54,7 +54,7 @@ class TestAppengineSocket(SocketLevelTest):
         context.load_verify_locations('test/certs/server.crt')
         sock = socket.create_connection(
             (self.server_thread.host, self.server_thread.port))
-        ssl_sock = context.wrap_socket(sock)
+        ssl_sock = context.wrap_socket(sock, do_handshake_on_connect=False)
         assert ssl_sock.selected_npn_protocol() == 'h2'
         ssl_sock.close()
         self.tear_down()

--- a/test/test_appengine.py
+++ b/test/test_appengine.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""
+Tests the ssl compatibility module for appengine.
+"""
+import hyper
+from hyper import ssl_compat_appengine
+from server import SocketLevelTest
+import socket
+import pytest
+
+
+class TestAppengine(object):
+    """
+    Test cases for ssl_compat_appengine module.
+    """
+
+    def test_field_existences(self):
+        assert ssl_compat_appengine.PROTOCOL_TLSv1 is not None
+        assert ssl_compat_appengine.PROTOCOL_SSLv23 is not None
+        assert ssl_compat_appengine.PROTOCOL_SSLv3 is not None
+        assert ssl_compat_appengine.CERT_NONE is not None
+        assert ssl_compat_appengine.CERT_OPTIONAL is not None
+        assert ssl_compat_appengine.CERT_REQUIRED is not None
+        assert ssl_compat_appengine.OP_NO_COMPRESSION is not None
+        assert ssl_compat_appengine.match_hostname is not None
+        assert ssl_compat_appengine.SSLContext is not None
+
+    def test_SSLContext(self):
+        context = ssl_compat_appengine.SSLContext(
+            ssl_compat_appengine.PROTOCOL_SSLv23)
+        context.set_default_verify_paths()
+        assert context.protocol_version == ssl_compat_appengine.PROTOCOL_SSLv23
+
+
+class TestAppengineSocket(SocketLevelTest):
+    """
+    Test case for wrap_socket.
+    """
+    h2 = False
+
+    def socket_handler(self, listener):
+        sock = listener.accept()[0]
+        sock.close()
+
+    def test_wrap_socket(self):
+        self.set_up()
+        self._start_server(self.socket_handler)
+        context = ssl_compat_appengine.SSLContext(
+            ssl_compat_appengine.PROTOCOL_SSLv23)
+        context.set_default_verify_paths()
+        context.verify_mode = ssl_compat_appengine.CERT_NONE
+        context.verify_hostname = False
+        # This invocation makes sure it does not fail.
+        context.load_verify_locations('test/certs/server.crt')
+        sock = socket.create_connection(
+            (self.server_thread.host, self.server_thread.port))
+        ssl_sock = context.wrap_socket(sock)
+        assert ssl_sock.selected_npn_protocol() == 'h2'
+        ssl_sock.close()
+        self.tear_down()


### PR DESCRIPTION
This is a patch to provide the SSL comptibility module working within AppEngine. This change does not enable hyper working on AppEngine yet, but I think this would help approaching to it.