### PR TITLE
Make passphrase a bytestring.

### DIFF
--- a/test/test_hyper_SSLContext.py
+++ b/test/test_hyper_SSLContext.py
@@ -39,5 +39,5 @@ class TestHyperSSLContext(object):
         context.load_cert_chain(
             certfile=CLIENT_CERT_FILE,
             keyfile=CLIENT_KEY_FILE,
-            password='abc123'
+            password=b'abc123'
         )


### PR DESCRIPTION
This should resolve some Python 3.2 test breakages.