### PR TITLE
Allow protocol version to be specified, useful if ALPN is unavailable

### DIFF
--- a/hyper/http20/connection.py
+++ b/hyper/http20/connection.py
@@ -66,7 +66,8 @@ class HTTP20Connection(object):
         and one also isn't provided in the ``proxy`` parameter, defaults to 8080.
     """
     def __init__(self, host, port=None, secure=None, window_manager=None, enable_push=False,
-                 ssl_context=None, proxy_host=None, proxy_port=None, **kwargs):
+                 ssl_context=None, proxy_host=None, proxy_port=None,
+                 force_proto=None, **kwargs):
         """
         Creates an HTTP/2 connection to a specific server.
         """
@@ -100,6 +101,8 @@ class HTTP20Connection(object):
         #: size to improve performance: decrease it to conserve memory.
         #: Defaults to 64kB.
         self.network_buffer_size = 65536
+
+        self.force_proto = force_proto
 
         # Create the mutable state.
         self.__wm_class = window_manager or FlowControlManager
@@ -249,7 +252,8 @@ class HTTP20Connection(object):
 
             if self.secure:
                 assert not self.proxy_host, "Using a proxy with HTTPS not yet supported."
-                sock, proto = wrap_socket(sock, host, self.ssl_context)
+                sock, proto = wrap_socket(sock, host, self.ssl_context,
+                                          force_proto=self.force_proto)
             else:
                 proto = H2C_PROTOCOL
 

--- a/hyper/tls.py
+++ b/hyper/tls.py
@@ -24,7 +24,7 @@ _context = None
 cert_loc = path.join(path.dirname(__file__), 'certs.pem')
 
 
-def wrap_socket(sock, server_hostname, ssl_context=None):
+def wrap_socket(sock, server_hostname, ssl_context=None, force_proto=None):
     """
     A vastly simplified SSL wrapping function. We'll probably extend this to
     do more things later.
@@ -49,16 +49,19 @@ def wrap_socket(sock, server_hostname, ssl_context=None):
         except AttributeError:
             ssl.verify_hostname(ssl_sock, server_hostname)  # pyopenssl
 
-    proto = None
+    if force_proto != None:
+        proto = force_proto
+    else:
+        proto = None
 
-    # ALPN is newer, so we prefer it over NPN. The odds of us getting different
-    # answers is pretty low, but let's be sure.
-    with ignore_missing():
-        proto = ssl_sock.selected_alpn_protocol()
+        # ALPN is newer, so we prefer it over NPN. The odds of us getting
+        # different answers is pretty low, but let's be sure.
+        with ignore_missing():
+            proto = ssl_sock.selected_alpn_protocol()
 
-    with ignore_missing():
-        if proto is None:
-            proto = ssl_sock.selected_npn_protocol()
+        with ignore_missing():
+            if proto is None:
+                proto = ssl_sock.selected_npn_protocol()
 
     return (ssl_sock, proto)
 


### PR DESCRIPTION
I needed this when connecting to the new HTTP/2 Apple Push Notification Service with python 2.7.11 on a platform where the openssl support available did not include ALPN (ssl.HAS_ALPN was False, ssl.HAS_NPN is True).

The Apple Push Notification Service doesn't allow negotiation by NPN, only ALPN works, so the following assertion in hyper/http20/connection.py:
`assert proto in H2_NPN_PROTOCOLS or proto == H2C_PROTOCOL`
would fail for me as proto would end up None as a result of wrap_socket in hyper/tls.py expecting either NPN or ALPN to work.

I was able to determine elsewhere with a working ALPN implementation that Apple Push Notification Service protocol is always 'h2'. So the point of this change is to allow a user who knows what the protocol will be to override, I supply 'h2' for the force_proto argument provided here and things work.