### PR TITLE
bugfix issue #152 plus test case

### DIFF
--- a/hyper/cli.py
+++ b/hyper/cli.py
@@ -164,7 +164,12 @@ def set_request_data(args):
     body, headers, params = {}, {}, {}
     for i in args.items:
         if i.sep == SEP_HEADERS:
-            headers[i.key] = i.value
+            # :key:value case
+            if i.key == '':
+                k, v = i.value.split(':')
+                headers[':' + k] = v
+            else:
+                headers[i.key] = i.value
         elif i.sep == SEP_QUERY:
             params[i.key] = i.value
         elif i.sep == SEP_DATA:

--- a/hyper/packages/hpack/hpack.py
+++ b/hyper/packages/hpack/hpack.py
@@ -223,13 +223,23 @@ class Encoder(object):
         representation: the same is true if they are in the static table.
         Otherwise, a literal representation will be used.
         """
-        log.debug("HPACK encoding %s", headers)
         header_block = []
 
         # Turn the headers into a list of tuples if possible. This is the
         # natural way to interact with them in HPACK.
         if isinstance(headers, dict):
             headers = headers.items()
+
+        # special headers need to come first in the header block
+        headers_helper = []
+        for h in headers:
+            if h[0][0] == ':':
+                headers_helper = [h] + headers_helper
+            else:
+                headers_helper.append(h)
+        headers = headers_helper
+
+        log.debug("HPACK encoding %s", headers)
 
         # Next, walk across the headers and turn them all into bytestrings.
         headers = [(_to_bytes(n), _to_bytes(v)) for n, v in headers]

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -110,11 +110,20 @@ def test_cli_with_system_exit(argv):
      {'method': 'GET', 'url.path': '/?param=test'}),
     (['POST', 'example.com', 'data=test'],
      {'method': 'POST', 'body': '{"data": "test"}'}),
+    (['GET', 'example.com', ':authority:example.org'],
+     {'method': 'GET', 'headers': {
+                            ':authority': 'example.org'}}),
+    (['GET', 'example.com', ':authority:example.org', 'x-test:header'],
+     {'method': 'GET', 'headers': {
+                             ':authority': 'example.org', 
+                             'x-test':'header'}}),
 ], ids=[
     'specified "--debug" option',
     'specified host and additional header',
     'specified host and get parameter',
     'specified host and post data',
+    'specified host and override default header',
+    'specified host and override default header and additional header',
 ])
 def test_parse_argument(argv, expected):
     args = parse_argument(argv)


### PR DESCRIPTION
Generated output:

hyper --debug GET https://google.com:443/ authority:google.ru
...
HPACK encoding [(':method', 'GET'), (':scheme', 'https'), (':authority', 'google.com'), (':path', '/'), ('authority', 'google.ru')]

hyper --debug GET https://google.com:443/ :authority:google.ru
...
HPACK encoding [(':method', 'GET'), (':scheme', 'https'), (':path', '/'), (':authority', 'google.ru')]

hyper --debug GET https://google.com:443/ authority:google.ru accept-charset:utf-8
...
HPACK encoding [(':method', 'GET'), (':scheme', 'https'), (':authority', 'google.com'), (':path', '/'), ('accept-charset', 'utf-8'), ('authority', 'google.ru')]

So input authority:google.ru is not changing default ':authority' header value which I think is OK.
Based on https://http2.github.io/http2-spec/compression.html ("A. Static Table Definition" section) ':authority' is predefined header whereas 'authority ' is just additional header.   

But when I run something like this:
hyper --debug GET https://google.com:443/ :authority:google.ru accept-charset:utf-8
the following error occurs:

Url Info: {'secure': True, 'fragment': None, 'netloc': 'google.com:443', 'host': 'google.com', 'query': None, 'path': '/', 'scheme': 'https', 'port': 443}
Commandline Argument: Namespace(_url='https://google.com:443/', body=None, debug=True, h2=False, headers={'accept-charset': 'utf-8', ':authority': 'google.ru'}, items=[<hyper.cli.KeyValue object at 0x7f3dc105b910>, <hyper.cli.KeyValue object at 0x7f3dc105b950>], method='GET', url=<hyper.cli.UrlInfo object at 0x7f3dc105b2d0>)
Selected protocol: h2
Sending frame SettingsFrame on stream 0
Received frame SettingsFrame on stream 0
Sending frame SettingsFrame on stream 0
Received frame WindowUpdateFrame on stream 0
HPACK encoding [(':method', 'GET'), (':scheme', 'https'), (':path', '/'), ('accept-charset', 'utf-8'), (':authority', 'google.ru')]
Adding (':method', 'GET') to the header table
Encoding 2 with 7 bits
Adding (':scheme', 'https') to the header table
Encoding 7 with 7 bits
Adding (':path', '/') to the header table
Encoding 4 with 7 bits
Adding ('accept-charset', 'utf-8') to the header table
Encoding 15 with 6 bits
Encoding 4 with 7 bits
Adding (':authority', 'google.ru') to the header table
Encoding 1 with 6 bits
Encoding 7 with 7 bits
Encoded header block to ���O��2��A��皂�e�
Sending frame HeadersFrame on stream 1
Received frame SettingsFrame on stream 0
Received frame GoAwayFrame on stream 0
Close stream 1
Sending frame GoAwayFrame on stream 0
Traceback (most recent call last):
  File "/usr/local/bin/hyper", line 9, in <module>
    load_entry_point('hyper==0.5.0', 'console_scripts', 'hyper')()
  File "/usr/local/lib/python2.7/dist-packages/hyper-0.5.0-py2.7.egg/hyper/cli.py", line 249, in main
    data = request(args)
  File "/usr/local/lib/python2.7/dist-packages/hyper-0.5.0-py2.7.egg/hyper/cli.py", line 239, in request
    response = conn.get_response()
  File "/usr/local/lib/python2.7/dist-packages/hyper-0.5.0-py2.7.egg/hyper/common/connection.py", line 124, in get_response
    return self._conn.get_response(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/hyper-0.5.0-py2.7.egg/hyper/http20/connection.py", line 207, in get_response
    return HTTP20Response(stream.getheaders(), stream)
  File "/usr/local/lib/python2.7/dist-packages/hyper-0.5.0-py2.7.egg/hyper/http20/stream.py", line 318, in getheaders
    self._recv_cb()
  File "/usr/local/lib/python2.7/dist-packages/hyper-0.5.0-py2.7.egg/hyper/http20/connection.py", line 727, in _recv_cb
    self._consume_single_frame()
  File "/usr/local/lib/python2.7/dist-packages/hyper-0.5.0-py2.7.egg/hyper/http20/connection.py", line 623, in _consume_single_frame
    self._consume_frame_payload(frame, data)
  File "/usr/local/lib/python2.7/dist-packages/hyper-0.5.0-py2.7.egg/hyper/http20/connection.py", line 707, in _consume_frame_payload
    self.receive_frame(frame)
  File "/usr/local/lib/python2.7/dist-packages/hyper-0.5.0-py2.7.egg/hyper/http20/connection.py", line 452, in receive_frame
    raise ConnectionError(error_string)
hyper.http20.exceptions.ConnectionError: Encountered error INTERNAL_ERROR 0x2: Implementation fault

HPACK looks good, headers were added any ideas...