### PR TITLE
Fixup HTTPHeaderMap replacing.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,14 @@
 Release History
 ===============
 
+dev
+---
+
+*Bugfixes*
+
+- Overriding HTTP/2 special headers no longer leads to ill-formed header blocks
+  with special headers at the end.
+
 0.5.0 (2015-10-11)
 ------------------
 

--- a/test/test_headers.py
+++ b/test/test_headers.py
@@ -272,8 +272,8 @@ class TestHTTPHeaderMap(object):
 
         assert list(h.items()) == [
             (b'name', b'value'),
-            (b'name3', b'value3'),
             (b'name2', b'42'),
+            (b'name3', b'value3'),
             (b'name4', b'other_value'),
         ]
 

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -122,8 +122,8 @@ class TestHyperConnection(object):
         assert list(s.headers.items()) == [
             (b':method', b'GET'),
             (b':scheme', b'https'),
-            (b':path', b'/'),
             (b':authority', b'www.example.org'),
+            (b':path', b'/'),
             (b'name', b'value2'),
         ]
 
@@ -581,7 +581,7 @@ class TestHyperConnection(object):
 
         def consume_single_frame():
             mutable['counter'] += 1
-            
+
         c._consume_single_frame = consume_single_frame
         c._recv_cb()
 
@@ -779,7 +779,7 @@ class TestHyperStream(object):
             (b"name", b"value"),
             (b"other_name", b"other_value")
         ]
-        
+
     def test_stream_opening_sends_headers(self):
         def data_callback(frame):
             assert isinstance(frame, HeadersFrame)
@@ -1548,7 +1548,7 @@ class TestUtilities(object):
 class NullEncoder(object):
     @staticmethod
     def encode(headers):
-        
+
         def to_str(v):
             if is_py2:
                 return str(v)
@@ -1557,7 +1557,7 @@ class NullEncoder(object):
                     v = str(v, 'utf-8')
                 return v
 
-        return '\n'.join("%s%s" % (to_str(name), to_str(val)) 
+        return '\n'.join("%s%s" % (to_str(name), to_str(val))
                          for name, val in headers)
 
 


### PR DESCRIPTION
Replacing headers in the `HTTPHeaderMap` would previously *append* the replacement value. This was fine for standard headers, but a nightmare for the HTTP/2 special headers, which RFC 7540 mandates *must* appear at the start of the header block.

This change resolves that problem.