### PR TITLE
Improve handling of socket errors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 Cory Benfield
+Copyright (c) 2014 Cory Benfield, Google Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
- Use the default connection timeout set by socket.setdefaulttimeout().

* I.e, don't specify one, until there is [an API][1] for timeouts, it's
probably better for libraries to be able to set the socket timeout
outside of hyper via [setdefaulttimeout][2]

- Updates error handling to simulate blocking behaviour when the socket
  is in timeout mode (which is internally a kind of non-blocking
  mode). Specifically, during reads, add
  * handling of specific ssl.SSLErrors WANT_READ and WANT_WRITE
  * handling of errno.EAGAIN and errno.EINTR

[1]: https://github.com/Lukasa/hyper/issues/187
[2]: https://docs.python.org/2/library/socket.html#socket.setdefaulttimeout