### PR TITLE
Added missing self.connect() in HTTP11Connection.__enter__

### DIFF
--- a/hyper/http11/connection.py
+++ b/hyper/http11/connection.py
@@ -377,6 +377,7 @@ class HTTP11Connection(object):
     # The following two methods are the implementation of the context manager
     # protocol.
     def __enter__(self):
+        self.connect()
         return self
 
     def __exit__(self, type, value, tb):

--- a/test/test_http11.py
+++ b/test/test_http11.py
@@ -510,6 +510,17 @@ class TestHTTP11Connection(object):
         assert 'File-like bodies must return bytestrings. ' \
                'Got: {}'.format(int) in str(exc_info)
 
+    def test_context_manager_enter_returns_self(self):
+        c = HTTP11Connection('httpbin.org')
+        with c as conn:
+            assert conn is c
+
+    def test_context_manager_connects_and_disconnects(self):
+        c = HTTP11Connection('httpbin.org')
+        with c:
+            assert c._sock is not None
+        assert c._sock is None
+
 
 class TestHTTP11Response(object):
     def test_short_circuit_read(self):


### PR DESCRIPTION
Previously the method was a noop returning self, so
using the with statement on an HTTP11Connection
wouldn't work correctly.
Also added tests for the context manager.
