### PR TITLE
Correct a test that fails sporadically

### DIFF
--- a/test/test_http11.py
+++ b/test/test_http11.py
@@ -477,15 +477,16 @@ class TestHTTP11Connection(object):
         c = HTTP11Connection('httpbin.org')
 
         rogue_element = 123
+        body = [b'legal1', b'legal2', rogue_element]
+        body_size = sum(len(bytes(x)) for x in body)
         with pytest.raises(ValueError) as exc_info:
             # content-length set so body type is set to BODY_FLAT. value
             # doesn't matter
-            body = ['legal1', 'legal2', rogue_element]
             c.request(
                 'GET',
                 '/get',
                 body=body,
-                headers={'content-length': str(len(map(str, body)))}
+                headers={'content-length': str(body_size)}
             )
         assert 'Elements in iterable body must be bytestrings. Illegal ' \
                'element: {}'.format(rogue_element) \

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -361,7 +361,9 @@ class TestHyperIntegration(SocketLevelTest):
             sock.send(f.serialize())
 
             # Now, send a headers frame again, containing trailing headers.
-            f = build_headers_frame([(':res', 'no'), ('trailing', 'sure')], e)
+            f = build_headers_frame([
+                ('trialing', 'no'),
+                ('trailing', 'sure')], e)
             f.flags.add('END_STREAM')
             f.stream_id = 1
             sock.send(f.serialize())
@@ -385,9 +387,10 @@ class TestHyperIntegration(SocketLevelTest):
         # Confirm that we got the trailing headers, and that they don't contain
         # reserved headers.
         assert resp.trailers['trailing'] == [b'sure']
+        assert resp.trailers['trialing'] == [b'no']
         assert resp.trailers.get(':res') is None
         assert len(resp.headers) == 1
-        assert len(resp.trailers) == 1
+        assert len(resp.trailers) == 2
 
         # Awesome, we're done now.
         recv_event.wait(5)
@@ -429,7 +432,9 @@ class TestHyperIntegration(SocketLevelTest):
             time.sleep(0.5)
 
             # Now, send a headers frame again, containing trailing headers.
-            f = build_headers_frame([(':res', 'no'), ('trailing', 'sure')], e)
+            f = build_headers_frame([
+                ('trialing', 'no'),
+                ('trailing', 'sure')], e)
             f.flags.add('END_STREAM')
             f.stream_id = 1
             sock.send(f.serialize())
@@ -453,9 +458,9 @@ class TestHyperIntegration(SocketLevelTest):
         # reserved headers. More importantly, check the trailers *first*,
         # before we read from the stream.
         assert resp.trailers['trailing'] == [b'sure']
-        assert resp.trailers.get(':res') is None
+        assert resp.trailers['trialing'] == [b'no']
         assert len(resp.headers) == 1
-        assert len(resp.trailers) == 1
+        assert len(resp.trailers) == 2
 
         # Confirm that the stream is still readable.
         assert resp.read() == b'have some data'


### PR DESCRIPTION
- this is really just replacing str with bytes.
- the body is initialized outside the test to make it easy to tell what actually failed