### PR TITLE
Modify how stream resets are reported.

### DIFF
--- a/hyper/http20/stream.py
+++ b/hyper/http20/stream.py
@@ -14,7 +14,6 @@ Each stream is identified by a monotonically increasing integer, assigned to
 the stream by the endpoint that initiated the stream.
 """
 from ..common.headers import HTTPHeaderMap
-from .exceptions import StreamResetError
 from .util import h2_safe_headers
 import logging
 
@@ -201,7 +200,7 @@ class Stream(object):
         Stream forcefully reset.
         """
         self.remote_closed = True
-        raise StreamResetError("Stream forcefully closed")
+        self._close_cb(self.stream_id)
 
     def get_headers(self):
         """

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -678,7 +678,7 @@ class TestHyperIntegration(SocketLevelTest):
         conn._recv_cb()
 
         # However, attempting to get the response should.
-        with pytest.raises(KeyError):
+        with pytest.raises(StreamResetError):
             conn.get_response(stream_id)
 
         # Awesome, we're done now.
@@ -716,13 +716,13 @@ class TestHyperIntegration(SocketLevelTest):
         conn = self.get_connection()
         conn.request('GET', '/')
 
-        # Now, eat the RstStream frames. The first one throws a
-        # StreamResetError.
-        with pytest.raises(StreamResetError):
-            conn._single_read()
-
-        # The next should throw no exception.
+        # Now, eat the Rst frames. These should not cause an exception.
         conn._single_read()
+        conn._single_read()
+
+        # However, attempting to get the response should.
+        with pytest.raises(StreamResetError):
+            conn.get_response(1)
 
         assert conn.reset_streams == set([1])
 


### PR DESCRIPTION
Fixes #147

Make the Stream when the stream is next accessed rather than immediately
the data is read.  This should avoid some errors that might occur when
there are multiple concurrent readers.