### PR TITLE
Re-implement HTTP/2 plaintext upgrade, as before.

### DIFF
--- a/hyper/common/connection.py
+++ b/hyper/common/connection.py
@@ -137,13 +137,9 @@ class HTTPConnection(object):
                 self._host, self._port, **self._h2_kwargs
             )
 
-            self._conn._sock = e.sock
+            self._conn._connect_upgrade(e.sock)
             # stream id 1 is used by the upgrade request and response
             # and is half-closed by the client
-            self._conn._new_stream(stream_id=1, local_closed=True)
-
-            # HTTP/2 preamble must be sent after receipt of a HTTP/1.1 101
-            self._conn._send_preamble()
 
             return self._conn.get_response(1)
 

--- a/hyper/http20/connection.py
+++ b/hyper/http20/connection.py
@@ -357,6 +357,27 @@ class HTTP20Connection(object):
 
             self._send_preamble()
 
+    def _connect_upgrade(self, sock):
+        """
+        Called by the generic HTTP connection when we're being upgraded. Locks
+        in a new socket and places the backing state machine into an upgrade
+        state, then sends the preamble.
+        """
+        self._sock = sock
+
+        with self._conn as conn:
+            conn.initiate_upgrade_connection()
+            conn.update_settings(
+                {h2.settings.ENABLE_PUSH: int(self._enable_push)}
+            )
+        self._send_outstanding_data()
+
+        # The server will also send an initial settings frame, so get it.
+        self._recv_cb()
+
+        s = self._new_stream(local_closed=True)
+        self.recent_stream = s
+
     def _send_preamble(self):
         """
         Sends the necessary HTTP/2 preamble.

--- a/hyper/http20/connection.py
+++ b/hyper/http20/connection.py
@@ -373,10 +373,12 @@ class HTTP20Connection(object):
         self._send_outstanding_data()
 
         # The server will also send an initial settings frame, so get it.
-        self._recv_cb()
-
+        # However, we need to make sure our stream state is set up properly
+        # first, or any extra data we receive might cause us problems.
         s = self._new_stream(local_closed=True)
         self.recent_stream = s
+
+        self._recv_cb()
 
     def _send_preamble(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ except AttributeError:
 
 
 def resolve_install_requires():
-    basic_dependencies = ['h2~=2.0', 'hyperframe~=3.2']
+    basic_dependencies = ['h2>=2.3,<3.0', 'hyperframe~=3.2']
 
     if py_version == (3, 3):
         basic_dependencies.extend(

--- a/test/test_abstraction.py
+++ b/test/test_abstraction.py
@@ -110,6 +110,9 @@ class DummyH2Connection(object):
     def _send_preamble(self):
         pass
 
+    def _connect_upgrade(self, sock):
+        self._sock = sock
+
     def _new_stream(self, *args, **kwargs):
         pass
 

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -859,6 +859,82 @@ class TestHyperIntegration(SocketLevelTest):
 
         self.tear_down()
 
+    def test_upgrade(self):
+        self.set_up(secure=False)
+
+        recv_event = threading.Event()
+        wait_event = threading.Event()
+
+        def socket_handler(listener):
+            sock = listener.accept()[0]
+
+            # First read the HTTP/1.1 request
+            data = b''
+            while not data.endswith(b'\r\n\r\n'):
+                data += sock.recv(65535)
+
+            # Check it's an upgrade.
+            assert b'upgrade: h2c\r\n' in data
+
+            # Send back an upgrade message.
+            data = (
+                b'HTTP/1.1 101 Switching Protocols\r\n'
+                b'Server: some-server\r\n'
+                b'Connection: upgrade\r\n'
+                b'Upgrade: h2c\r\n'
+                b'\r\n'
+            )
+            sock.sendall(data)
+
+            # We get a message for connection open, specifically the preamble.
+            receive_preamble(sock)
+
+            # Now, send the headers for the response. This response has a body.
+            f = build_headers_frame([(':status', '200')])
+            f.stream_id = 1
+            sock.sendall(f.serialize())
+
+            # Send the first two chunks.
+            f = DataFrame(1)
+            f.data = b'hello'
+            sock.sendall(f.serialize())
+            f = DataFrame(1)
+            f.data = b'there'
+            sock.sendall(f.serialize())
+
+            # Now, delay a bit. We want to wait a half a second before we send
+            # the next frame.
+            wait_event.wait(5)
+            time.sleep(0.5)
+            f = DataFrame(1)
+            f.data = b'world'
+            f.flags.add('END_STREAM')
+            sock.sendall(f.serialize())
+
+            # Wait for the message from the main thread.
+            recv_event.set()
+            sock.close()
+
+        self._start_server(socket_handler)
+        conn = hyper.HTTPConnection(self.host, self.port, self.secure)
+        conn.request('GET', '/')
+        resp = conn.get_response()
+
+        # Confirm the status code.
+        assert resp.status == 200
+
+        first_chunk = resp.read(10)
+        wait_event.set()
+        second_chunk = resp.read(5)
+
+        assert first_chunk == b'hellothere'
+        assert second_chunk == b'world'
+
+        # Awesome, we're done now.
+        recv_event.wait(5)
+
+        self.tear_down()
+
 
 class TestRequestsAdapter(SocketLevelTest):
     # This uses HTTP/2.


### PR DESCRIPTION
This should bring us back to feature parity for the last release of hyper.