### PR TITLE
Tolerate errors in resetting streams.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,10 @@ Release History
 dev
 ---
 
+*Bugfixes*
+
+- Tolerate errors when attempting to send a RST_STREAM frame.
+
 0.6.0 (2016-05-06)
 ------------------
 

--- a/hyper/http20/connection.py
+++ b/hyper/http20/connection.py
@@ -727,7 +727,7 @@ class HTTP20Connection(object):
         # Ignore this read if some other thread has recently read data from
         # from the requested stream.
         #
-        # The lock here looks broad, but is need to ensure correct behavior
+        # The lock here looks broad, but is needed to ensure correct behavior
         # when there are multiple readers of the same stream.  It is
         # re-acquired in the calls to self._single_read.
         #


### PR DESCRIPTION
If we can't send a RstStreamFrame, I don't think we care that much: the stream is clearly totally boned, and we should be able to clear up our state.

Resolves #244.