### PR TITLE
Include ssl dependencies into ssl_compat for python versions <2.7.9

### DIFF
--- a/hyper/ssl_compat.py
+++ b/hyper/ssl_compat.py
@@ -48,7 +48,8 @@ def _proxy(method):
         return getattr(self._conn, method)(*args, **kwargs)
     return inner
 
-
+# Referenced in hyper/http20/connection.py. These values come from the python ssl package, and
+# must be defined in this file for hyper to work in python versions <2.7.9
 SSL_ERROR_WANT_READ = 2
 SSL_ERROR_WANT_WRITE = 3
 

--- a/hyper/ssl_compat.py
+++ b/hyper/ssl_compat.py
@@ -48,8 +48,9 @@ def _proxy(method):
         return getattr(self._conn, method)(*args, **kwargs)
     return inner
 
-# Referenced in hyper/http20/connection.py. These values come from the python ssl package, and
-# must be defined in this file for hyper to work in python versions <2.7.9
+# Referenced in hyper/http20/connection.py. These values come 
+# from the python ssl package, and must be defined in this file 
+# for hyper to work in python versions <2.7.9
 SSL_ERROR_WANT_READ = 2
 SSL_ERROR_WANT_WRITE = 3
 

--- a/hyper/ssl_compat.py
+++ b/hyper/ssl_compat.py
@@ -50,6 +50,8 @@ def _proxy(method):
 
 
 # TODO missing some attributes
+SSL_ERROR_WANT_READ = 2
+SSL_ERROR_WANT_WRITE = 3
 class SSLError(OSError):
     pass
 

--- a/hyper/ssl_compat.py
+++ b/hyper/ssl_compat.py
@@ -49,9 +49,11 @@ def _proxy(method):
     return inner
 
 
-# TODO missing some attributes
 SSL_ERROR_WANT_READ = 2
 SSL_ERROR_WANT_WRITE = 3
+
+
+# TODO missing some attributes
 class SSLError(OSError):
     pass
 


### PR DESCRIPTION
I'm not sure what the long term plan is for ssl_compat, but this is what I'm using on my machine as I am pinned to a version of python lower than 2.7.9. If there is a better way, let me know!