### PR TITLE
Fixup opening windows of closed streams.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ script:
           py.test test/
         else
           coverage run -m py.test test/
-          coverage combine
           coverage report
         fi
       fi

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ envlist = py27, py34, py35, pypy, lint
 deps= -r{toxinidir}/test_requirements.txt
 commands=
     coverage run -m py.test {toxinidir}/test/
-    coverage combine
     coverage report
 
 [testenv:pypy]


### PR DESCRIPTION
Seems this slipped through the cracks: EAFP is to be preferred to LBYL.