### PR TITLE
removing stream from recent_recv_streams on clean close

### DIFF
--- a/hyper/http20/connection.py
+++ b/hyper/http20/connection.py
@@ -817,6 +817,7 @@ class HTTP20Connection(object):
         """
         try:
             del self.streams[stream_id]
+            self.recent_recv_streams.discard(stream_id)
         except KeyError:
             pass
 


### PR DESCRIPTION
This addresses #265. Not sure if the test is overkill for such a minor change, but I figured I'd err on the side of 101% coverage :) I'll strip it out if it's unneeded.