### PR TITLE
Fixup failing import tests

### DIFF
--- a/hyper/ssl_compat.py
+++ b/hyper/ssl_compat.py
@@ -48,6 +48,7 @@ def _proxy(method):
         return getattr(self._conn, method)(*args, **kwargs)
     return inner
 
+
 # Referenced in hyper/http20/connection.py. These values come
 # from the python ssl package, and must be defined in this file
 # for hyper to work in python versions <2.7.9

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
-    install_requires=['h2>=2.4,<3.0', 'hyperframe>=3.2,<4.0'],
+    install_requires=['h2>=2.4,<3.0,!=2.5.0', 'hyperframe>=3.2,<4.0'],
     tests_require=['pytest', 'requests', 'mock'],
     cmdclass={'test': PyTest},
     entry_points={

--- a/test/test_import.py
+++ b/test/test_import.py
@@ -5,6 +5,7 @@ import sys
 
 
 class TestImportPython2(object):
+    @pytest.mark.skipif(sys.version_info[0] == 3, reason="Python 2 only")
     def test_cannot_import_python_2(self, monkeypatch):
         monkeypatch.setattr(sys, 'version_info', (2, 6, 5, 'final', 0))
         with pytest.raises(ImportError):
@@ -12,6 +13,7 @@ class TestImportPython2(object):
 
 
 class TestImportPython3(object):
+    @pytest.mark.skipif(sys.version_info[0] == 2, reason="Python 3 only")
     def test_cannot_import_python_32(self, monkeypatch):
         monkeypatch.setattr(sys, 'version_info', (3, 2, 3, 'final', 0))
         with pytest.raises(ImportError):


### PR DESCRIPTION
Frankly, those import tests never made much sense when we were running on a completely different platform: they were just not failing for the right reasons.