### PR TITLE
Support generator type data

### DIFF
--- a/hyper/http20/connection.py
+++ b/hyper/http20/connection.py
@@ -776,7 +776,7 @@ class HTTP20Connection(object):
                 self._get_stream(stream_id)
 
             # TODO: Re-evaluate this.
-            self._single_read()
+            # self._single_read()
             count = 9
             retry_wait = 0.05  # can improve responsiveness to delay the retry
 

--- a/hyper/http20/stream.py
+++ b/hyper/http20/stream.py
@@ -115,7 +115,7 @@ class Stream(object):
 
             # If ``final`` is True, send a empty chunk to end stream
             if final:
-                self._send_chunk('', final)
+                self._send_chunk(b'', final)
         elif hasattr(data, 'read'):
             while True:
                 chunk = data.read(MAX_CHUNK)


### PR DESCRIPTION
1. support generator type data

   Usage:
   ```
   from hyper import HTTPConnection

   def gen():
        yield 'hello'
        yield 'world'

   conn = HTTPConnection('http2bin.org:443')
   conn.request('POST', '/post', body=gen())
   print(conn.get_response().read())
   ```

2. fix that data with integral multiple of the `MAX_CHUNK` size does not end stream.
