### PR TITLE
Fix integration test for Python 3

### DIFF
--- a/hyper/http20/util.py
+++ b/hyper/http20/util.py
@@ -52,9 +52,9 @@ def h2_safe_headers(headers):
     """
     stripped = {
         i.lower().strip()
-        for k, v in headers if k == 'connection'
-        for i in v.split(',')
+        for k, v in headers if k == b'connection'
+        for i in v.split(b',')
     }
-    stripped.add('connection')
+    stripped.add(b'connection')
 
     return [header for header in headers if header[0] not in stripped]

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -1176,27 +1176,27 @@ class TestUtilities(object):
         assert True
 
     def test_stripping_connection_header(self):
-        headers = [('one', 'two'), ('connection', 'close')]
-        stripped = [('one', 'two')]
+        headers = [(b'one', b'two'), (b'connection', b'close')]
+        stripped = [(b'one', b'two')]
 
         assert h2_safe_headers(headers) == stripped
 
     def test_stripping_related_headers(self):
         headers = [
-            ('one', 'two'), ('three', 'four'), ('five', 'six'),
-            ('connection', 'close, three, five')
+            (b'one', b'two'), (b'three', b'four'), (b'five', b'six'),
+            (b'connection', b'close, three, five')
         ]
-        stripped = [('one', 'two')]
+        stripped = [(b'one', b'two')]
 
         assert h2_safe_headers(headers) == stripped
 
     def test_stripping_multiple_connection_headers(self):
         headers = [
-            ('one', 'two'), ('three', 'four'), ('five', 'six'),
-            ('connection', 'close'),
-            ('connection', 'three, five')
+            (b'one', b'two'), (b'three', b'four'), (b'five', b'six'),
+            (b'connection', b'close'),
+            (b'connection', b'three, five')
         ]
-        stripped = [('one', 'two')]
+        stripped = [(b'one', b'two')]
 
         assert h2_safe_headers(headers) == stripped
 


### PR DESCRIPTION
Originally this two tests `test_adapter_received_values` and `test_adapter_sending_values` would fail in Python 3 due to `connection` header not being removed, which is a bug of the `h2_safe_headers` function. 

`headers(class HTTPHeaderMap)` stores bytes because we call `to_bytestring_tuple` when initiating it. While in Python 2 `bytes` is equivalent to `str`, and `h2_safe_headers` can find `'connection'` successfully, in Python 3 `b'connection' != 'connection'`, so this header is not removed.

Some affected tests are also modified.