### PR TITLE
More informative error message if no protocol found for http2

### DIFF
--- a/hyper/http20/connection.py
+++ b/hyper/http20/connection.py
@@ -375,7 +375,10 @@ class HTTP20Connection(object):
                 proto = H2C_PROTOCOL
 
             log.debug("Selected NPN protocol: %s", proto)
-            assert proto in H2_NPN_PROTOCOLS or proto == H2C_PROTOCOL
+            assert proto in H2_NPN_PROTOCOLS or proto == H2C_PROTOCOL, (
+                "No suitable protocol found. Supported protocols: %s. "
+                "Check your OpenSSL version."
+            ) % ','.join(H2_NPN_PROTOCOLS + [H2C_PROTOCOL])
 
             self._sock = BufferedSocket(sock, self.network_buffer_size)
 

--- a/test/test_http20.py
+++ b/test/test_http20.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""
+test_http20.py
+~~~~~~~~~~~~~~
+
+Unit tests for hyper's HTTP/2.0 implementation.
+"""
+import pytest
+from mock import patch
+
+from server import SocketLevelTest
+
+
+class TestHTTP20Connection(SocketLevelTest):
+    h2 = True
+
+    def test_useful_error_with_no_protocol(self):
+        self.set_up()
+
+        def socket_handler(listener):
+            sock = listener.accept()[0]
+            sock.close()
+
+        self._start_server(socket_handler)
+        conn = self.get_connection()
+
+        with patch('hyper.http20.connection.wrap_socket') as mock:
+            mock.return_value = (None, None)
+            with pytest.raises(AssertionError) as exc_info:
+                conn.connect()
+        assert (
+            "No suitable protocol found."
+            in
+            str(exc_info)
+        )
+        assert (
+            "Check your OpenSSL version."
+            in
+            str(exc_info)
+        )
+
+        self.tear_down()

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -12,6 +12,7 @@ import time
 import hyper
 import hyper.http11.connection
 import pytest
+from mock import patch
 from h2.frame_buffer import FrameBuffer
 from hyper.compat import ssl
 from hyper.contrib import HTTP20Adapter
@@ -34,8 +35,8 @@ if ssl is not None:
     hyper.tls._context.check_hostname = False
     hyper.tls._context.verify_mode = ssl.CERT_NONE
 
-    # Cover our bases because NPN doesn't yet work on all our test platforms.
-    hyper.http20.connection.H2_NPN_PROTOCOLS += ['', None]
+# Cover our bases because NPN doesn't yet work on all our test platforms.
+PROTOCOLS = hyper.http20.connection.H2_NPN_PROTOCOLS + ['', None]
 
 
 def decode_frame(frame_data):
@@ -76,6 +77,7 @@ def receive_preamble(sock):
     return
 
 
+@patch('hyper.http20.connection.H2_NPN_PROTOCOLS', PROTOCOLS)
 class TestHyperIntegration(SocketLevelTest):
     # These are HTTP/2 tests.
     h2 = True
@@ -1031,6 +1033,7 @@ class TestHyperIntegration(SocketLevelTest):
         self.tear_down()
 
 
+@patch('hyper.http20.connection.H2_NPN_PROTOCOLS', PROTOCOLS)
 class TestRequestsAdapter(SocketLevelTest):
     # This uses HTTP/2.
     h2 = True


### PR DESCRIPTION
Today I ran into an issue with hyper, where the OpenSSL version in my environment was too old (1.0.1) so it did not have ALPN, which was required by the server. This is of course not a bug/problem with hyper itself, however the error message I got from hyper was not that helpful (it was an `AssertionError` with no help message). This pull request suggests a new check after wrapping the socket in SSL to see if a protocol was selected and if not tells the user that none was selected and suggests the user check their OpenSSL version.