### PR TITLE
Add ENABLE_PUSH flag in the Upgrade HTTP2-Settings header

### DIFF
--- a/hyper/http11/connection.py
+++ b/hyper/http11/connection.py
@@ -78,6 +78,7 @@ class HTTP11Connection(object):
 
         # only send http upgrade headers for non-secure connection
         self._send_http_upgrade = not self.secure
+        self._enable_push = int(kwargs.get('enable_push', False))
 
         self.ssl_context = ssl_context
         self._sock = None
@@ -276,6 +277,7 @@ class HTTP11Connection(object):
         # Settings header.
         http2_settings = SettingsFrame(0)
         http2_settings.settings[SettingsFrame.INITIAL_WINDOW_SIZE] = 65535
+        http2_settings.settings[SettingsFrame.ENABLE_PUSH] = self._enable_push
         encoded_settings = base64.urlsafe_b64encode(
             http2_settings.serialize_body()
         )


### PR DESCRIPTION
Push flag required for the case the initial upgrade request triggered server push.