### PR TITLE
Add ENABLE_PUSH flag in the Upgrade HTTP2-Settings header

### DIFF
--- a/hyper/common/connection.py
+++ b/hyper/common/connection.py
@@ -62,7 +62,8 @@ class HTTPConnection(object):
         self._port = port
         self._h1_kwargs = {
             'secure': secure, 'ssl_context': ssl_context,
-            'proxy_host': proxy_host, 'proxy_port': proxy_port
+            'proxy_host': proxy_host, 'proxy_port': proxy_port,
+            'enable_push': enable_push
         }
         self._h2_kwargs = {
             'window_manager': window_manager, 'enable_push': enable_push,

--- a/hyper/http11/connection.py
+++ b/hyper/http11/connection.py
@@ -78,6 +78,7 @@ class HTTP11Connection(object):
 
         # only send http upgrade headers for non-secure connection
         self._send_http_upgrade = not self.secure
+        self._enable_push = kwargs.get('enable_push')
 
         self.ssl_context = ssl_context
         self._sock = None
@@ -276,6 +277,10 @@ class HTTP11Connection(object):
         # Settings header.
         http2_settings = SettingsFrame(0)
         http2_settings.settings[SettingsFrame.INITIAL_WINDOW_SIZE] = 65535
+        if self._enable_push is not None:
+            http2_settings.settings[SettingsFrame.ENABLE_PUSH] = (
+                int(self._enable_push)
+            )
         encoded_settings = base64.urlsafe_b64encode(
             http2_settings.serialize_body()
         )

--- a/test/test_abstraction.py
+++ b/test/test_abstraction.py
@@ -19,6 +19,7 @@ class TestHTTPConnection(object):
             'proxy_host': False,
             'proxy_port': False,
             'other_kwarg': True,
+            'enable_push': True,
         }
 
     def test_h2_kwargs(self):

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -48,7 +48,6 @@ def frame_buffer():
 
 
 class TestHyperConnection(object):
-
     def test_connections_accept_hosts_and_ports(self):
         c = HTTP20Connection(host='www.google.com', port=8080)
         assert c.host == 'www.google.com'
@@ -500,7 +499,6 @@ class TestHyperConnection(object):
 
     def test_send_tolerate_peer_gone(self):
         class ErrorSocket(DummySocket):
-
             def sendall(self, data):
                 raise socket.error(errno.EPIPE)
 
@@ -703,7 +701,6 @@ class TestHyperConnection(object):
 
 
 class FrameEncoderMixin(object):
-
     def setup_method(self, method):
         self.frames = []
         self.encoder = Encoder()
@@ -737,7 +734,6 @@ class FrameEncoderMixin(object):
 
 
 class TestServerPush(FrameEncoderMixin):
-
     def request(self, enable_push=True):
         self.conn = HTTP20Connection('www.google.com', enable_push=enable_push)
         self.conn._sock = DummySocket()
@@ -963,7 +959,6 @@ class TestServerPush(FrameEncoderMixin):
 
 
 class TestResponse(object):
-
     def test_status_is_stripped_from_headers(self):
         headers = HTTPHeaderMap([(':status', '200')])
         resp = HTTP20Response(headers, None)
@@ -1114,7 +1109,6 @@ class TestResponse(object):
 
 
 class TestHTTP20Adapter(object):
-
     def test_adapter_reuses_connections(self):
         a = HTTP20Adapter()
         conn1 = a.get_connection('http2bin.org', 80, 'http')
@@ -1138,7 +1132,6 @@ class TestHTTP20Adapter(object):
 
 
 class TestUtilities(object):
-
     def test_combining_repeated_headers(self):
         test_headers = [
             (b'key1', b'val1'),
@@ -1466,7 +1459,6 @@ class TestUpgradingPush(FrameEncoderMixin):
 
 # Some utility classes for the tests.
 class NullEncoder(object):
-
     @staticmethod
     def encode(headers):
 
@@ -1483,7 +1475,6 @@ class NullEncoder(object):
 
 
 class FixedDecoder(object):
-
     def __init__(self, result):
         self.result = result
 
@@ -1492,7 +1483,6 @@ class FixedDecoder(object):
 
 
 class DummySocket(object):
-
     def __init__(self):
         self.queue = []
         self._buffer = BytesIO()
@@ -1530,7 +1520,6 @@ class DummySocket(object):
 
 
 class DummyStream(object):
-
     def __init__(self, data, trailers=None):
         self.data = data
         self.data_frames = []

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -76,10 +76,11 @@ def reusable_frame_buffer(buffer):
 def receive_preamble(sock):
     # Receive the HTTP/2 'preamble'.
     client_preface = b'PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n'
-    timeout = time.time() + 5
     got = b''
-    while len(got) < len(client_preface) and time.time() < timeout:
-        got += sock.recv(len(client_preface) - len(got))
+    while len(got) < len(client_preface):
+        tmp = sock.recv(len(client_preface) - len(got))
+        assert len(tmp) > 0, "unexpected EOF"
+        got += tmp
 
     assert got == client_preface, "client preface mismatch"
 

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -12,6 +12,7 @@ import time
 import hyper
 import hyper.http11.connection
 import pytest
+from contextlib import contextmanager
 from mock import patch
 from h2.frame_buffer import FrameBuffer
 from hyper.compat import ssl
@@ -64,17 +65,30 @@ def frame_buffer():
     return buffer
 
 
+@contextmanager
+def reusable_frame_buffer(buffer):
+    # FrameBuffer does not return new iterator for iteration.
+    data = buffer.data
+    yield buffer
+    buffer.data = data
+
+
 def receive_preamble(sock):
     # Receive the HTTP/2 'preamble'.
-    first = sock.recv(65535)
+    client_preface = b'PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n'
+    timeout = time.time() + 5
+    got = b''
+    while len(got) < len(client_preface) and time.time() < timeout:
+        got += sock.recv(len(client_preface) - len(got))
 
-    # Work around some bugs: if the first message received was only the PRI
-    # string, aim to receive a settings frame as well.
-    if len(first) <= len(b'PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n'):
-        sock.recv(65535)
+    assert got == client_preface, "client preface mismatch"
+
+    # Send server side HTTP/2 preface
     sock.send(SettingsFrame(0).serialize())
-    sock.recv(65535)
-    return
+    # Drain to let the client proceed.
+    # Note that in the lower socket level, this method is not
+    # just doing "receive".
+    return sock.recv(65535)
 
 
 @patch('hyper.http20.connection.H2_NPN_PROTOCOLS', PROTOCOLS)
@@ -138,7 +152,7 @@ class TestHyperIntegration(SocketLevelTest):
         self._start_server(socket_handler)
         conn = self.get_connection()
         conn.connect()
-        send_event.wait()
+        send_event.wait(5)
 
         # Get the chunk of data after the preamble and decode it into frames.
         # We actually expect two, but only the second one contains ENABLE_PUSH.
@@ -242,7 +256,7 @@ class TestHyperIntegration(SocketLevelTest):
             f = SettingsFrame(0)
             sock.send(f.serialize())
 
-            send_event.wait()
+            send_event.wait(5)
             sock.recv(65535)
             sock.close()
 
@@ -260,6 +274,7 @@ class TestHyperIntegration(SocketLevelTest):
     def test_closed_responses_remove_their_streams_from_conn(self):
         self.set_up()
 
+        req_event = threading.Event()
         recv_event = threading.Event()
 
         def socket_handler(listener):
@@ -270,6 +285,8 @@ class TestHyperIntegration(SocketLevelTest):
             receive_preamble(sock)
             sock.recv(65535)
 
+            # Wait for request
+            req_event.wait(5)
             # Now, send the headers for the response.
             f = build_headers_frame([(':status', '200')])
             f.stream_id = 1
@@ -282,6 +299,7 @@ class TestHyperIntegration(SocketLevelTest):
         self._start_server(socket_handler)
         conn = self.get_connection()
         conn.request('GET', '/')
+        req_event.set()
         resp = conn.get_response()
 
         # Close the response.
@@ -296,6 +314,7 @@ class TestHyperIntegration(SocketLevelTest):
     def test_receiving_responses_with_no_body(self):
         self.set_up()
 
+        req_event = threading.Event()
         recv_event = threading.Event()
 
         def socket_handler(listener):
@@ -306,6 +325,8 @@ class TestHyperIntegration(SocketLevelTest):
             receive_preamble(sock)
             sock.recv(65535)
 
+            # Wait for request
+            req_event.wait(5)
             # Now, send the headers for the response. This response has no body
             f = build_headers_frame(
                 [(':status', '204'), ('content-length', '0')]
@@ -321,6 +342,7 @@ class TestHyperIntegration(SocketLevelTest):
         self._start_server(socket_handler)
         conn = self.get_connection()
         conn.request('GET', '/')
+        req_event.set()
         resp = conn.get_response()
 
         # Confirm the status code.
@@ -338,6 +360,7 @@ class TestHyperIntegration(SocketLevelTest):
     def test_receiving_trailers(self):
         self.set_up()
 
+        req_event = threading.Event()
         recv_event = threading.Event()
 
         def socket_handler(listener):
@@ -350,6 +373,8 @@ class TestHyperIntegration(SocketLevelTest):
             receive_preamble(sock)
             sock.recv(65535)
 
+            # Wait for request
+            req_event.wait(5)
             # Now, send the headers for the response.
             f = build_headers_frame(
                 [(':status', '200'), ('content-length', '14')],
@@ -372,12 +397,13 @@ class TestHyperIntegration(SocketLevelTest):
             sock.send(f.serialize())
 
             # Wait for the message from the main thread.
-            recv_event.set()
+            recv_event.wait(5)
             sock.close()
 
         self._start_server(socket_handler)
         conn = self.get_connection()
         conn.request('GET', '/')
+        req_event.set()
         resp = conn.get_response()
 
         # Confirm the status code.
@@ -396,13 +422,14 @@ class TestHyperIntegration(SocketLevelTest):
         assert len(resp.trailers) == 2
 
         # Awesome, we're done now.
-        recv_event.wait(5)
+        recv_event.set()
 
         self.tear_down()
 
     def test_receiving_trailers_before_reading(self):
         self.set_up()
 
+        req_event = threading.Event()
         recv_event = threading.Event()
         wait_event = threading.Event()
 
@@ -416,6 +443,8 @@ class TestHyperIntegration(SocketLevelTest):
             receive_preamble(sock)
             sock.recv(65535)
 
+            # Wait for request
+            req_event.wait(5)
             # Now, send the headers for the response.
             f = build_headers_frame(
                 [(':status', '200'), ('content-length', '14')],
@@ -449,6 +478,7 @@ class TestHyperIntegration(SocketLevelTest):
         self._start_server(socket_handler)
         conn = self.get_connection()
         conn.request('GET', '/')
+        req_event.set()
         resp = conn.get_response()
 
         # Confirm the status code.
@@ -647,6 +677,7 @@ class TestHyperIntegration(SocketLevelTest):
         """
         self.set_up()
 
+        req_event = threading.Event()
         recv_event = threading.Event()
 
         def socket_handler(listener):
@@ -657,6 +688,8 @@ class TestHyperIntegration(SocketLevelTest):
             receive_preamble(sock)
             sock.recv(65535)
 
+            # Wait for request
+            req_event.wait(5)
             # Now, send the headers for the response. This response has no
             # body.
             f = build_headers_frame(
@@ -673,6 +706,7 @@ class TestHyperIntegration(SocketLevelTest):
         self._start_server(socket_handler)
         conn = self.get_connection()
         stream_id = conn.request('GET', '/')
+        req_event.set()
 
         # Now, trigger the RST_STREAM frame by closing the stream.
         conn._send_rst_frame(stream_id, 0)
@@ -696,6 +730,7 @@ class TestHyperIntegration(SocketLevelTest):
         """
         self.set_up()
 
+        req_event = threading.Event()
         recv_event = threading.Event()
 
         def socket_handler(listener):
@@ -706,6 +741,8 @@ class TestHyperIntegration(SocketLevelTest):
             receive_preamble(sock)
             sock.recv(65535)
 
+            # Wait for request
+            req_event.wait(5)
             # Now, send two RST_STREAM frames.
             for _ in range(0, 2):
                 f = RstStreamFrame(1)
@@ -718,6 +755,7 @@ class TestHyperIntegration(SocketLevelTest):
         self._start_server(socket_handler)
         conn = self.get_connection()
         conn.request('GET', '/')
+        req_event.set()
 
         # Now, eat the Rst frames. These should not cause an exception.
         conn._single_read()
@@ -737,6 +775,7 @@ class TestHyperIntegration(SocketLevelTest):
     def test_read_chunked_http2(self):
         self.set_up()
 
+        req_event = threading.Event()
         recv_event = threading.Event()
         wait_event = threading.Event()
 
@@ -748,6 +787,8 @@ class TestHyperIntegration(SocketLevelTest):
             receive_preamble(sock)
             sock.recv(65535)
 
+            # Wait for request
+            req_event.wait(5)
             # Now, send the headers for the response. This response has a body.
             f = build_headers_frame([(':status', '200')])
             f.stream_id = 1
@@ -777,6 +818,7 @@ class TestHyperIntegration(SocketLevelTest):
         self._start_server(socket_handler)
         conn = self.get_connection()
         conn.request('GET', '/')
+        req_event.set()
         resp = conn.get_response()
 
         # Confirm the status code.
@@ -805,6 +847,7 @@ class TestHyperIntegration(SocketLevelTest):
     def test_read_delayed(self):
         self.set_up()
 
+        req_event = threading.Event()
         recv_event = threading.Event()
         wait_event = threading.Event()
 
@@ -816,6 +859,8 @@ class TestHyperIntegration(SocketLevelTest):
             receive_preamble(sock)
             sock.recv(65535)
 
+            # Wait for request
+            req_event.wait(5)
             # Now, send the headers for the response. This response has a body.
             f = build_headers_frame([(':status', '200')])
             f.stream_id = 1
@@ -845,6 +890,7 @@ class TestHyperIntegration(SocketLevelTest):
         self._start_server(socket_handler)
         conn = self.get_connection()
         conn.request('GET', '/')
+        req_event.set()
         resp = conn.get_response()
 
         # Confirm the status code.
@@ -958,6 +1004,8 @@ class TestHyperIntegration(SocketLevelTest):
 
             receive_preamble(sock)
 
+            # Wait for the message from the main thread.
+            send_event.wait()
             # Send the headers for the response. This response has no body.
             f = build_headers_frame(
                 [(':status', '200'), ('content-length', '0')]
@@ -965,9 +1013,6 @@ class TestHyperIntegration(SocketLevelTest):
             f.flags.add('END_STREAM')
             f.stream_id = 1
             sock.sendall(f.serialize())
-
-            # Wait for the message from the main thread.
-            send_event.wait()
             sock.close()
 
         self._start_server(socket_handler)
@@ -996,7 +1041,7 @@ class TestHyperIntegration(SocketLevelTest):
                 data += sock.recv(65535)
             assert b'upgrade: h2c\r\n' in data
 
-            send_event.wait()
+            send_event.wait(5)
 
             # We need to send back a response.
             resp = (
@@ -1038,7 +1083,7 @@ class TestRequestsAdapter(SocketLevelTest):
     # This uses HTTP/2.
     h2 = True
 
-    def test_adapter_received_values(self, monkeypatch):
+    def test_adapter_received_values(self, monkeypatch, frame_buffer):
         self.set_up()
 
         # We need to patch the ssl_wrap_socket method to ensure that we
@@ -1051,17 +1096,20 @@ class TestRequestsAdapter(SocketLevelTest):
 
         monkeypatch.setattr(hyper.http11.connection, 'wrap_socket', wrap)
 
-        data = []
-        send_event = threading.Event()
-
         def socket_handler(listener):
             sock = listener.accept()[0]
 
             # Do the handshake: conn header, settings, send settings, recv ack.
-            receive_preamble(sock)
+            frame_buffer.add_data(receive_preamble(sock))
 
             # Now expect some data. One headers frame.
-            data.append(sock.recv(65535))
+            req_wait = True
+            while req_wait:
+                frame_buffer.add_data(sock.recv(65535))
+                with reusable_frame_buffer(frame_buffer) as fr:
+                    for f in fr:
+                        if isinstance(f, HeadersFrame):
+                            req_wait = False
 
             # Respond!
             h = HeadersFrame(1)
@@ -1078,8 +1126,6 @@ class TestRequestsAdapter(SocketLevelTest):
             d.data = b'1234567890' * 2
             d.flags.add('END_STREAM')
             sock.send(d.serialize())
-
-            send_event.wait(5)
             sock.close()
 
         self._start_server(socket_handler)
@@ -1093,11 +1139,9 @@ class TestRequestsAdapter(SocketLevelTest):
         assert r.headers[b'Content-Type'] == b'not/real'
         assert r.content == b'1234567890' * 2
 
-        send_event.set()
-
         self.tear_down()
 
-    def test_adapter_sending_values(self, monkeypatch):
+    def test_adapter_sending_values(self, monkeypatch, frame_buffer):
         self.set_up()
 
         # We need to patch the ssl_wrap_socket method to ensure that we
@@ -1110,17 +1154,20 @@ class TestRequestsAdapter(SocketLevelTest):
 
         monkeypatch.setattr(hyper.http11.connection, 'wrap_socket', wrap)
 
-        data = []
-
         def socket_handler(listener):
             sock = listener.accept()[0]
 
             # Do the handshake: conn header, settings, send settings, recv ack.
-            receive_preamble(sock)
+            frame_buffer.add_data(receive_preamble(sock))
 
             # Now expect some data. One headers frame and one data frame.
-            data.append(sock.recv(65535))
-            data.append(sock.recv(65535))
+            req_wait = True
+            while req_wait:
+                frame_buffer.add_data(sock.recv(65535))
+                with reusable_frame_buffer(frame_buffer) as fr:
+                    for f in fr:
+                        if isinstance(f, DataFrame):
+                            req_wait = False
 
             # Respond!
             h = HeadersFrame(1)
@@ -1137,7 +1184,6 @@ class TestRequestsAdapter(SocketLevelTest):
             d.data = b'1234567890' * 2
             d.flags.add('END_STREAM')
             sock.send(d.serialize())
-
             sock.close()
 
         self._start_server(socket_handler)
@@ -1152,11 +1198,10 @@ class TestRequestsAdapter(SocketLevelTest):
         # Assert about the sent values.
         assert r.status_code == 200
 
-        f = decode_frame(data[0])
-        assert isinstance(f, HeadersFrame)
+        frames = list(frame_buffer)
+        assert isinstance(frames[-2], HeadersFrame)
 
-        f = decode_frame(data[1])
-        assert isinstance(f, DataFrame)
-        assert f.data == b'hi there'
+        assert isinstance(frames[-1], DataFrame)
+        assert frames[-1].data == b'hi there'
 
         self.tear_down()


### PR DESCRIPTION
Push flag required for the case the initial upgrade request triggered server push. This PR is a relaxed version of #310 , which was more strict on server push I/O timing.
Test send/recv timing was fixed, because connection state machine does not get corrupted during h2c upgrade migration.