### PR TITLE
Implement HTTPS proxy support

### DIFF
--- a/hyper/common/connection.py
+++ b/hyper/common/connection.py
@@ -44,8 +44,9 @@ class HTTPConnection(object):
     :param proxy_host: (optional) The proxy to connect to.  This can be an IP
         address or a host name and may include a port.
     :param proxy_port: (optional) The proxy port to connect to. If not provided
-        and one also isn't provided in the ``proxy`` parameter, defaults to
-        8080.
+        and one also isn't provided in the ``proxy_host`` parameter, defaults
+        to 8080.
+    :param proxy_headers: (optional) The headers to send to a proxy.
     """
     def __init__(self,
                  host,
@@ -56,6 +57,7 @@ class HTTPConnection(object):
                  ssl_context=None,
                  proxy_host=None,
                  proxy_port=None,
+                 proxy_headers=None,
                  **kwargs):
 
         self._host = host
@@ -63,12 +65,13 @@ class HTTPConnection(object):
         self._h1_kwargs = {
             'secure': secure, 'ssl_context': ssl_context,
             'proxy_host': proxy_host, 'proxy_port': proxy_port,
-            'enable_push': enable_push
+            'proxy_headers': proxy_headers, 'enable_push': enable_push
         }
         self._h2_kwargs = {
             'window_manager': window_manager, 'enable_push': enable_push,
             'secure': secure, 'ssl_context': ssl_context,
-            'proxy_host': proxy_host, 'proxy_port': proxy_port
+            'proxy_host': proxy_host, 'proxy_port': proxy_port,
+            'proxy_headers': proxy_headers
         }
 
         # Add any unexpected kwargs to both dictionaries.

--- a/hyper/common/exceptions.py
+++ b/hyper/common/exceptions.py
@@ -71,3 +71,22 @@ class MissingCertFile(Exception):
     The certificate file could not be found.
     """
     pass
+
+
+# Create our own ConnectionError.
+try:  # pragma: no cover
+    ConnectionError = ConnectionError
+except NameError:  # pragma: no cover
+    class ConnectionError(Exception):
+        """
+        An error occurred during connection to a host.
+        """
+
+
+class ProxyError(ConnectionError):
+    """
+    An error occurred during connection to a proxy.
+    """
+    def __init__(self, message, response):
+        self.response = response
+        super(ProxyError, self).__init__(message)

--- a/hyper/http11/response.py
+++ b/hyper/http11/response.py
@@ -27,7 +27,8 @@ class HTTP11Response(object):
 
     version = HTTPVersion.http11
 
-    def __init__(self, code, reason, headers, sock, connection=None):
+    def __init__(self, code, reason, headers, sock, connection=None,
+                 request_method=None):
         #: The reason phrase returned by the server.
         self.reason = reason
 
@@ -62,11 +63,19 @@ class HTTP11Response(object):
             b'chunked' in self.headers.get(b'transfer-encoding', [])
         )
 
-        # One of the following must be true: we must expect that the connection
-        # will be closed following the body, or that a content-length was sent,
-        # or that we're getting a chunked response.
-        # FIXME: Remove naked assert, replace with something better.
-        assert self._expect_close or self._length is not None or self._chunked
+        # When content-length is absent and response is not chunked,
+        # body length is determined by connection closure.
+        # https://tools.ietf.org/html/rfc7230#section-3.3.3
+        if self._length is None and not self._chunked:
+            # 200 response to a CONNECT request means that proxy has connected
+            # to the target host and it will start forwarding everything sent
+            # from the either side. Thus we must not try to read body of this
+            # response. Socket of current connection will be taken over by
+            # the code that has sent a CONNECT request.
+            if not (request_method is not None and
+                    b'CONNECT' == request_method.upper() and
+                    code == 200):
+                self._expect_close = True
 
         # This object is used for decompressing gzipped request bodies. Right
         # now we only support gzip because that's all the RFC mandates of us.

--- a/hyper/http20/exceptions.py
+++ b/hyper/http20/exceptions.py
@@ -5,6 +5,7 @@ hyper/http20/exceptions
 
 This defines exceptions used in the HTTP/2 portion of hyper.
 """
+from ..common.exceptions import ConnectionError as CommonConnectionError
 
 
 class HTTP20Error(Exception):
@@ -28,7 +29,7 @@ class HPACKDecodingError(HTTP20Error):
     pass
 
 
-class ConnectionError(HTTP20Error):
+class ConnectionError(CommonConnectionError, HTTP20Error):
     """
     The remote party signalled an error affecting the entire HTTP/2
     connection, and the connection has been closed.

--- a/test/test_abstraction.py
+++ b/test/test_abstraction.py
@@ -10,7 +10,7 @@ class TestHTTPConnection(object):
         c = HTTPConnection(
             'test', 443, secure=False, window_manager=True, enable_push=True,
             ssl_context=False, proxy_host=False, proxy_port=False,
-            other_kwarg=True
+            proxy_headers=False, other_kwarg=True
         )
 
         assert c._h1_kwargs == {
@@ -18,6 +18,7 @@ class TestHTTPConnection(object):
             'ssl_context': False,
             'proxy_host': False,
             'proxy_port': False,
+            'proxy_headers': False,
             'other_kwarg': True,
             'enable_push': True,
         }
@@ -26,7 +27,7 @@ class TestHTTPConnection(object):
         c = HTTPConnection(
             'test', 443, secure=False, window_manager=True, enable_push=True,
             ssl_context=True, proxy_host=False, proxy_port=False,
-            other_kwarg=True
+            proxy_headers=False, other_kwarg=True
         )
 
         assert c._h2_kwargs == {
@@ -36,6 +37,7 @@ class TestHTTPConnection(object):
             'ssl_context': True,
             'proxy_host': False,
             'proxy_port': False,
+            'proxy_headers': False,
             'other_kwarg': True,
         }
 

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -585,6 +585,41 @@ class TestHyperConnection(object):
             (b':path', b'/'),
         ]
 
+    def test_proxy_headers_presence_for_insecure_request(self):
+        sock = DummySocket()
+        c = HTTP20Connection(
+            'www.google.com', secure=False, proxy_host='localhost',
+            proxy_headers={'Proxy-Authorization': 'Basic ==='}
+        )
+        c._sock = sock
+        c.request('GET', '/')
+        s = c.recent_stream
+
+        assert list(s.headers.items()) == [
+            (b':method', b'GET'),
+            (b':scheme', b'http'),
+            (b':authority', b'www.google.com'),
+            (b':path', b'/'),
+            (b'proxy-authorization', b'Basic ==='),
+        ]
+
+    def test_proxy_headers_absence_for_secure_request(self):
+        sock = DummySocket()
+        c = HTTP20Connection(
+            'www.google.com', secure=True, proxy_host='localhost',
+            proxy_headers={'Proxy-Authorization': 'Basic ==='}
+        )
+        c._sock = sock
+        c.request('GET', '/')
+        s = c.recent_stream
+
+        assert list(s.headers.items()) == [
+            (b':method', b'GET'),
+            (b':scheme', b'https'),
+            (b':authority', b'www.google.com'),
+            (b':path', b'/'),
+        ]
+
     def test_recv_cb_n_times(self):
         sock = DummySocket()
         sock.can_read = True

--- a/test/test_integration_http11.py
+++ b/test/test_integration_http11.py
@@ -11,8 +11,9 @@ import threading
 import pytest
 
 from hyper.compat import ssl
-from server import SocketLevelTest
+from server import SocketLevelTest, SocketSecuritySetting
 from hyper.common.exceptions import HTTPUpgrade
+from hyper.common.util import to_bytestring
 
 # Turn off certificate verification for the tests.
 if ssl is not None:
@@ -119,8 +120,50 @@ class TestHyperH11Integration(SocketLevelTest):
 
         assert r.read() == b'hellotheresirfinalfantasy'
 
-    def test_proxy_request_response(self):
-        self.set_up(proxy=True)
+    def test_closing_response_without_headers(self):
+        self.set_up()
+
+        send_event = threading.Event()
+
+        def socket_handler(listener):
+            sock = listener.accept()[0]
+
+            # We should get the initial request.
+            data = b''
+            while not data.endswith(b'\r\n\r\n'):
+                data += sock.recv(65535)
+
+            send_event.wait()
+
+            # We need to send back a response.
+            resp = (
+                b'HTTP/1.1 200 OK\r\n'
+                b'Server: socket-level-server\r\n'
+                b'\r\n'
+            )
+            sock.send(resp)
+
+            sock.send(b'hi')
+
+            sock.close()
+
+        self._start_server(socket_handler)
+        c = self.get_connection()
+        c.request('GET', '/')
+        send_event.set()
+        r = c.get_response()
+
+        assert r.status == 200
+        assert r.reason == b'OK'
+        assert len(r.headers) == 1
+        assert r.headers[b'server'] == [b'socket-level-server']
+
+        assert r.read() == b'hi'
+
+        assert c._sock is None
+
+    def test_insecure_proxy_request_response(self):
+        self.set_up(secure=False, proxy=True)
 
         send_event = threading.Event()
 
@@ -162,6 +205,108 @@ class TestHyperH11Integration(SocketLevelTest):
         assert r.read() == b''
 
         assert c._sock is None
+
+    def test_secure_proxy_request_response(self):
+        self.set_up(secure=SocketSecuritySetting.SECURE_NO_AUTO_WRAP,
+                    proxy=True)
+
+        connect_request_headers = []
+        send_event = threading.Event()
+
+        def socket_handler(listener):
+            sock = listener.accept()[0]
+
+            # Read the CONNECT request
+            while not b''.join(connect_request_headers).endswith(b'\r\n\r\n'):
+                connect_request_headers.append(sock.recv(65535))
+
+            sock.send(b'HTTP/1.0 200 Connection established\r\n\r\n')
+
+            sock = self.server_thread.wrap_socket(sock)
+
+            # We should get the initial request.
+            data = b''
+            while not data.endswith(b'\r\n\r\n'):
+                data += sock.recv(65535)
+
+            send_event.wait()
+
+            # We need to send back a response.
+            resp = (
+                b'HTTP/1.1 201 No Content\r\n'
+                b'Server: socket-level-server\r\n'
+                b'Content-Length: 0\r\n'
+                b'Connection: close\r\n'
+                b'\r\n'
+            )
+            sock.send(resp)
+
+            sock.close()
+
+        self._start_server(socket_handler)
+        c = self.get_connection()
+        c.request('GET', '/')
+        send_event.set()
+        r = c.get_response()
+
+        assert r.status == 201
+        assert r.reason == b'No Content'
+        assert len(r.headers) == 3
+        assert r.headers[b'server'] == [b'socket-level-server']
+        assert r.headers[b'content-length'] == [b'0']
+        assert r.headers[b'connection'] == [b'close']
+
+        assert r.read() == b''
+
+        assert (to_bytestring(
+            'CONNECT %s:%d HTTP/1.1\r\n\r\n' % (c.host, c.port)) ==
+                b''.join(connect_request_headers))
+
+        assert c._sock is None
+
+    def test_proxy_connection_close_is_respected(self):
+        self.set_up(secure=False, proxy=True)
+
+        send_event = threading.Event()
+
+        def socket_handler(listener):
+            sock = listener.accept()[0]
+
+            # We should get the initial request.
+            data = b''
+            while not data.endswith(b'\r\n\r\n'):
+                data += sock.recv(65535)
+
+            send_event.wait()
+
+            # We need to send back a response.
+            resp = (
+                b'HTTP/1.0 407 Proxy Authentication Required\r\n'
+                b'Proxy-Authenticate: Basic realm="proxy"\r\n'
+                b'Proxy-Connection: close\r\n'
+                b'\r\n'
+            )
+            sock.send(resp)
+
+            sock.close()
+
+        self._start_server(socket_handler)
+        conn = self.get_connection()
+        conn.request('GET', '/')
+        send_event.set()
+
+        r = conn.get_response()
+
+        assert r.status == 407
+        assert r.reason == b'Proxy Authentication Required'
+        assert len(r.headers) == 2
+        assert r.headers[b'proxy-authenticate'] == [b'Basic realm="proxy"']
+        assert r.headers[b'proxy-connection'] == [b'close']
+
+        assert r.read() == b''
+
+        # Confirm the connection is closed.
+        assert conn._sock is None
 
     def test_response_with_body(self):
         self.set_up()


### PR DESCRIPTION
Related issue: #304

~~This is a very work in progress. It seems to work, but I would like to get your feedback whether I'm on a right track or not.~~

~~The main concern I have is about httplib: is it OK to use it for just sending `CONNECT` method to a proxy?~~ Though [HTTP/2 standard defines][1] CONNECT method as well, I guess it is an overkill to use it for just getting a raw socket from a proxy.

TODO:
- [x] Requests adapter: respect custom request ports when choosing a proxy
- [x] Validate proxy support on h2 w/o tls (h2c) (should we even think about it? I'm not sure)
- [x] ~~raise appropriate IO exceptions to distinguish between connection failure to proxy and a general IO exception~~ (to be done in a follow-up PR) 
- [x] Implement proxy authorization support
- [x] ~~Strip `Proxy-*` headers from response on HTTP proxying~~ (seems unneeded. requests doesn't do it)

[1]: https://tools.ietf.org/html/rfc7540#section-8.3