### PR TITLE
HTTP/1.1 parser fix, when response contains empty reason

### DIFF
--- a/hyper/http11/parser.py
+++ b/hyper/http11/parser.py
@@ -49,7 +49,7 @@ class Parser(object):
         if index == -1:
             return None
 
-        version, status, reason = temp_buffer[0:index].split(None, 2)
+        version, status, reason = (temp_buffer[0:index].split(None, 2) + [''])[:3]
         if not version.startswith(b'HTTP/1.'):
             raise ParseError("Not HTTP/1.X!")
 

--- a/hyper/http11/parser.py
+++ b/hyper/http11/parser.py
@@ -49,8 +49,8 @@ class Parser(object):
         if index == -1:
             return None
 
-        version, status, reason = \
-            (temp_buffer[0:index].split(None, 2) + [b''])[:3]
+        version, status, reason = (
+                temp_buffer[0:index].split(None, 2) + [b''])[:3]
         if not version.startswith(b'HTTP/1.'):
             raise ParseError("Not HTTP/1.X!")
 

--- a/hyper/http11/parser.py
+++ b/hyper/http11/parser.py
@@ -49,7 +49,8 @@ class Parser(object):
         if index == -1:
             return None
 
-        version, status, reason = (temp_buffer[0:index].split(None, 2) + [''])[:3]
+        version, status, reason = \
+            (temp_buffer[0:index].split(None, 2) + [''])[:3]
         if not version.startswith(b'HTTP/1.'):
             raise ParseError("Not HTTP/1.X!")
 

--- a/hyper/http11/parser.py
+++ b/hyper/http11/parser.py
@@ -50,7 +50,7 @@ class Parser(object):
             return None
 
         version, status, reason = \
-            (temp_buffer[0:index].split(None, 2) + [''])[:3]
+            (temp_buffer[0:index].split(None, 2) + [b''])[:3]
         if not version.startswith(b'HTTP/1.'):
             raise ParseError("Not HTTP/1.X!")
 

--- a/test/test_http11.py
+++ b/test/test_http11.py
@@ -328,6 +328,23 @@ class TestHTTP11Connection(object):
         received = b''.join(sock.queue)
 
         assert received == expected
+        
+    def test_response_with_empty_reason(self):
+        c = HTTP11Connection('httpbin.org')
+        c._sock = sock = DummySocket()
+
+        sock._buffer = BytesIO(
+            b"HTTP/1.1 201\r\n"
+            b"Connection: close\r\n"
+            b"Server: Socket\r\n"
+            b"Content-Length: 0\r\n"
+            b"\r\n"
+        )
+
+        r = c.get_response()
+        
+        assert r.status == 201
+        assert r.reason == b''
 
     def test_get_response(self):
         c = HTTP11Connection('httpbin.org')

--- a/test/test_http11.py
+++ b/test/test_http11.py
@@ -328,7 +328,7 @@ class TestHTTP11Connection(object):
         received = b''.join(sock.queue)
 
         assert received == expected
-        
+
     def test_response_with_empty_reason(self):
         c = HTTP11Connection('httpbin.org')
         c._sock = sock = DummySocket()
@@ -342,7 +342,7 @@ class TestHTTP11Connection(object):
         )
 
         r = c.get_response()
-        
+
         assert r.status == 201
         assert r.reason == b''
 

--- a/test/test_http11.py
+++ b/test/test_http11.py
@@ -334,7 +334,7 @@ class TestHTTP11Connection(object):
         c._sock = sock = DummySocket()
 
         sock._buffer = BytesIO(
-            b"HTTP/1.1 201\r\n"
+            b"HTTP/1.1 201 \r\n"
             b"Connection: close\r\n"
             b"Server: Socket\r\n"
             b"Content-Length: 0\r\n"


### PR DESCRIPTION
Sometimes response can come w/o reason-phrase.
Changes made according to the rfc2616 (6.1.1): The client is not required to examine or display the Reason- Phrase.