### PR TITLE
Check HTTP11 socket is initialized before closing

### DIFF
--- a/hyper/http11/connection.py
+++ b/hyper/http11/connection.py
@@ -385,7 +385,8 @@ class HTTP11Connection(object):
         .. warning:: This method should absolutely only be called when you are
                      certain the connection object is no longer needed.
         """
-        self._sock.close()
+        if self._sock is not None:
+            self._sock.close()
         self._sock = None
 
     # The following two methods are the implementation of the context manager

--- a/test/test_http11.py
+++ b/test/test_http11.py
@@ -529,6 +529,10 @@ class TestHTTP11Connection(object):
         assert 'File-like bodies must return bytestrings. ' \
                'Got: {}'.format(int) in str(exc_info)
 
+    def test_close_with_uninitialized_socket(self):
+        c = HTTP11Connection('httpbin.org')
+        c.close()
+
 
 class TestHTTP11Response(object):
     def test_short_circuit_read(self):


### PR DESCRIPTION
Ensures that the underlying socket exists before calling close on it. This allows us to exit a context safely if connect() hasn't been called

It also matches the behaviour in HTTP20Connection.