### PR TITLE
Fix some chars (!, =, etc) being treated as not allowed in userinfo of authority

### DIFF
--- a/hyper/packages/rfc3986/misc.py
+++ b/hyper/packages/rfc3986/misc.py
@@ -124,7 +124,7 @@ ip_literal = '\[({0}|{1})\]'.format(ipv6, ipv_future)
 HOST_PATTERN = '({0}|{1}|{2})'.format(reg_name, ipv4, ip_literal)
 
 SUBAUTHORITY_MATCHER = re.compile((
-    '^(?:(?P<userinfo>[A-Za-z0-9_.~\-%:]+)@)?'  # userinfo
+    '^(?:(?P<userinfo>[A-Za-z0-9\-._~%!$&\'()*+,;=:]+)@)?'  # userinfo
     '(?P<host>{0}?)'  # host
     ':?(?P<port>\d+)?$'  # port
     ).format(HOST_PATTERN))

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -67,6 +67,16 @@ class TestHyperConnection(object):
         assert c.proxy_host == 'localhost'
         assert c.proxy_port == 8443
 
+    def test_connections_can_parse_proxy_hosts_with_userinfo(self):
+        c = HTTP20Connection('www.google.com',
+                             proxy_host='azAz09!==:fakepaswd@localhost:8443')
+        # Note that the userinfo part is getting stripped out,
+        # it's not automatically added as Basic Auth header to
+        # the proxy_headers! It should be done manually.
+        assert c.host == 'www.google.com'
+        assert c.proxy_host == 'localhost'
+        assert c.proxy_port == 8443
+
     def test_connections_can_parse_proxy_hosts_and_ports(self):
         c = HTTP20Connection('www.google.com',
                              proxy_host='localhost',


### PR DESCRIPTION
As per https://tools.ietf.org/html/rfc3986#section-3.2.1

    userinfo    = *( unreserved / pct-encoded / sub-delims / ":" )

Where, according to https://tools.ietf.org/html/rfc3986#section-2.2 ,

    sub-delims  = "!" / "$" / "&" / "'" / "(" / ")"
                      / "*" / "+" / "," / ";" / "="

The `sub-delims` set of chars was added in this PR.

--

(a bit unrelated)

Hyper doesn't handle userinfo to automatically add Basic Auth header to requests. If `host` (or `proxy_host`) of connection contains userinfo, it's getting stripped out in the [to_host_port_tuple function](https://github.com/Lukasa/hyper/blob/e76f185207b4746052b1519cad13238c35195798/hyper/common/util.py#L35).

I feel it's not good to quietly eat up auth part without actually using it. Maybe at least we should issue a warning in this case?

