### PR TITLE
Add connection/read timeout for requests adapter

### DIFF
--- a/hyper/common/connection.py
+++ b/hyper/common/connection.py
@@ -58,6 +58,7 @@ class HTTPConnection(object):
                  proxy_host=None,
                  proxy_port=None,
                  proxy_headers=None,
+                 timeout=None,
                  **kwargs):
 
         self._host = host
@@ -78,8 +79,10 @@ class HTTPConnection(object):
         self._h1_kwargs.update(kwargs)
         self._h2_kwargs.update(kwargs)
 
+        self._timeout = timeout
+
         self._conn = HTTP11Connection(
-            self._host, self._port, **self._h1_kwargs
+            self._host, self._port, timeout=self._timeout, **self._h1_kwargs
         )
 
     def request(self, method, url, body=None, headers=None):
@@ -113,7 +116,8 @@ class HTTPConnection(object):
             assert e.negotiated in H2_NPN_PROTOCOLS
 
             self._conn = HTTP20Connection(
-                self._host, self._port, **self._h2_kwargs
+                self._host, self._port,
+                timeout=self._timeout, **self._h2_kwargs
             )
             self._conn._sock = e.sock
 
@@ -138,7 +142,8 @@ class HTTPConnection(object):
             assert e.negotiated == H2C_PROTOCOL
 
             self._conn = HTTP20Connection(
-                self._host, self._port, **self._h2_kwargs
+                self._host, self._port,
+                timeout=self._timeout, **self._h2_kwargs
             )
 
             self._conn._connect_upgrade(e.sock)

--- a/hyper/common/connection.py
+++ b/hyper/common/connection.py
@@ -66,23 +66,23 @@ class HTTPConnection(object):
         self._h1_kwargs = {
             'secure': secure, 'ssl_context': ssl_context,
             'proxy_host': proxy_host, 'proxy_port': proxy_port,
-            'proxy_headers': proxy_headers, 'enable_push': enable_push
+            'proxy_headers': proxy_headers, 'enable_push': enable_push,
+            'timeout': timeout
         }
         self._h2_kwargs = {
             'window_manager': window_manager, 'enable_push': enable_push,
             'secure': secure, 'ssl_context': ssl_context,
             'proxy_host': proxy_host, 'proxy_port': proxy_port,
-            'proxy_headers': proxy_headers
+            'proxy_headers': proxy_headers,
+            'timeout': timeout
         }
 
         # Add any unexpected kwargs to both dictionaries.
         self._h1_kwargs.update(kwargs)
         self._h2_kwargs.update(kwargs)
 
-        self._timeout = timeout
-
         self._conn = HTTP11Connection(
-            self._host, self._port, timeout=self._timeout, **self._h1_kwargs
+            self._host, self._port, **self._h1_kwargs
         )
 
     def request(self, method, url, body=None, headers=None):
@@ -116,8 +116,7 @@ class HTTPConnection(object):
             assert e.negotiated in H2_NPN_PROTOCOLS
 
             self._conn = HTTP20Connection(
-                self._host, self._port,
-                timeout=self._timeout, **self._h2_kwargs
+                self._host, self._port, **self._h2_kwargs
             )
             self._conn._sock = e.sock
 
@@ -142,8 +141,7 @@ class HTTPConnection(object):
             assert e.negotiated == H2C_PROTOCOL
 
             self._conn = HTTP20Connection(
-                self._host, self._port,
-                timeout=self._timeout, **self._h2_kwargs
+                self._host, self._port, **self._h2_kwargs
             )
 
             self._conn._connect_upgrade(e.sock)

--- a/hyper/contrib.py
+++ b/hyper/contrib.py
@@ -33,7 +33,7 @@ class HTTP20Adapter(HTTPAdapter):
         self.connections = {}
 
     def get_connection(self, host, port, scheme, cert=None, verify=True,
-                       proxy=None):
+                       proxy=None, **kwargs):
         """
         Gets an appropriate HTTP/2 connection object based on
         host/port/scheme/cert tuples.
@@ -77,7 +77,8 @@ class HTTP20Adapter(HTTPAdapter):
                 secure=secure,
                 ssl_context=ssl_context,
                 proxy_host=proxy_netloc,
-                proxy_headers=proxy_headers)
+                proxy_headers=proxy_headers,
+                **kwargs)
             self.connections[connection_key] = conn
 
         return conn
@@ -98,7 +99,8 @@ class HTTP20Adapter(HTTPAdapter):
             parsed.scheme,
             cert=cert,
             verify=verify,
-            proxy=proxy)
+            proxy=proxy,
+            **kwargs)
 
         # Build the selector.
         selector = parsed.path

--- a/hyper/contrib.py
+++ b/hyper/contrib.py
@@ -33,7 +33,7 @@ class HTTP20Adapter(HTTPAdapter):
         self.connections = {}
 
     def get_connection(self, host, port, scheme, cert=None, verify=True,
-                       proxy=None, **kwargs):
+                       proxy=None, timeout=None):
         """
         Gets an appropriate HTTP/2 connection object based on
         host/port/scheme/cert tuples.
@@ -78,7 +78,7 @@ class HTTP20Adapter(HTTPAdapter):
                 ssl_context=ssl_context,
                 proxy_host=proxy_netloc,
                 proxy_headers=proxy_headers,
-                **kwargs)
+                timeout=timeout)
             self.connections[connection_key] = conn
 
         return conn
@@ -93,6 +93,7 @@ class HTTP20Adapter(HTTPAdapter):
             proxy = prepend_scheme_if_needed(proxy, 'http')
 
         parsed = urlparse(request.url)
+        timeout = kwargs.get('timeout')
         conn = self.get_connection(
             parsed.hostname,
             parsed.port,
@@ -100,7 +101,7 @@ class HTTP20Adapter(HTTPAdapter):
             cert=cert,
             verify=verify,
             proxy=proxy,
-            **kwargs)
+            timeout=timeout)
 
         # Build the selector.
         selector = parsed.path

--- a/hyper/contrib.py
+++ b/hyper/contrib.py
@@ -84,7 +84,7 @@ class HTTP20Adapter(HTTPAdapter):
         return conn
 
     def send(self, request, stream=False, cert=None, verify=True, proxies=None,
-             **kwargs):
+             timeout=None, **kwargs):
         """
         Sends a HTTP message to the server.
         """
@@ -93,7 +93,6 @@ class HTTP20Adapter(HTTPAdapter):
             proxy = prepend_scheme_if_needed(proxy, 'http')
 
         parsed = urlparse(request.url)
-        timeout = kwargs.get('timeout')
         conn = self.get_connection(
             parsed.hostname,
             parsed.port,

--- a/hyper/http11/connection.py
+++ b/hyper/http11/connection.py
@@ -159,7 +159,6 @@ class HTTP11Connection(object):
             self._connect_timeout = timeout
             self._read_timeout = timeout
 
-
     def connect(self):
         """
         Connect to the server specified when the object was created. This is a
@@ -185,7 +184,7 @@ class HTTP11Connection(object):
                     timeout=self._connect_timeout
                 )
             else:
-                sock = socket.create_connection((self.host, self.port), 
+                sock = socket.create_connection((self.host, self.port),
                                                 timeout=self._connect_timeout)
             proto = None
 

--- a/hyper/http11/connection.py
+++ b/hyper/http11/connection.py
@@ -101,7 +101,7 @@ class HTTP11Connection(object):
 
     def __init__(self, host, port=None, secure=None, ssl_context=None,
                  proxy_host=None, proxy_port=None, proxy_headers=None,
-                 **kwargs):
+                 timeout=None, **kwargs):
         if port is None:
             self.host, self.port = to_host_port_tuple(host, default_port=80)
         else:
@@ -151,7 +151,6 @@ class HTTP11Connection(object):
         self.parser = Parser()
 
         # timeout
-        timeout = kwargs.get('timeout')
         if isinstance(timeout, tuple):
             self._connect_timeout = timeout[0]
             self._read_timeout = timeout[1]

--- a/hyper/http20/connection.py
+++ b/hyper/http20/connection.py
@@ -102,7 +102,7 @@ class HTTP20Connection(object):
     def __init__(self, host, port=None, secure=None, window_manager=None,
                  enable_push=False, ssl_context=None, proxy_host=None,
                  proxy_port=None, force_proto=None, proxy_headers=None,
-                 **kwargs):
+                 timeout=None, **kwargs):
         """
         Creates an HTTP/2 connection to a specific server.
         """
@@ -152,7 +152,6 @@ class HTTP20Connection(object):
         self.__init_state()
 
         # timeout
-        timeout = kwargs.get('timeout')
         if isinstance(timeout, tuple):
             self._connect_timeout = timeout[0]
             self._read_timeout = timeout[1]

--- a/hyper/http20/connection.py
+++ b/hyper/http20/connection.py
@@ -368,7 +368,7 @@ class HTTP20Connection(object):
                     timeout=self._connect_timeout
                 )
             else:
-                sock = socket.create_connection((self.host, self.port), 
+                sock = socket.create_connection((self.host, self.port),
                                                 timeout=self._connect_timeout)
 
             if self.secure:

--- a/test/server.py
+++ b/test/server.py
@@ -108,12 +108,13 @@ class SocketLevelTest(object):
     A test-class that defines a few helper methods for running socket-level
     tests.
     """
-    def set_up(self, secure=True, proxy=False):
+    def set_up(self, secure=True, proxy=False, timeout=None):
         self.host = None
         self.port = None
         self.socket_security = SocketSecuritySetting(secure)
         self.proxy = proxy
         self.server_thread = None
+        self.timeout = timeout
 
     def _start_server(self, socket_handler):
         """
@@ -146,18 +147,22 @@ class SocketLevelTest(object):
     def get_connection(self):
         if self.h2:
             if not self.proxy:
-                return HTTP20Connection(self.host, self.port, self.secure)
+                return HTTP20Connection(self.host, self.port, self.secure,
+                                        timeout=self.timeout)
             else:
                 return HTTP20Connection('http2bin.org', secure=self.secure,
                                         proxy_host=self.host,
-                                        proxy_port=self.port)
+                                        proxy_port=self.port,
+                                        timeout=self.timeout)
         else:
             if not self.proxy:
-                return HTTP11Connection(self.host, self.port, self.secure)
+                return HTTP11Connection(self.host, self.port, self.secure,
+                                        timeout=self.timeout)
             else:
                 return HTTP11Connection('httpbin.org', secure=self.secure,
                                         proxy_host=self.host,
-                                        proxy_port=self.port)
+                                        proxy_port=self.port,
+                                        timeout=self.timeout)
 
     def get_encoder(self):
         """

--- a/test/test_abstraction.py
+++ b/test/test_abstraction.py
@@ -10,7 +10,7 @@ class TestHTTPConnection(object):
         c = HTTPConnection(
             'test', 443, secure=False, window_manager=True, enable_push=True,
             ssl_context=False, proxy_host=False, proxy_port=False,
-            proxy_headers=False, other_kwarg=True
+            proxy_headers=False, other_kwarg=True, timeout=5
         )
 
         assert c._h1_kwargs == {
@@ -21,13 +21,14 @@ class TestHTTPConnection(object):
             'proxy_headers': False,
             'other_kwarg': True,
             'enable_push': True,
+            'timeout': 5,
         }
 
     def test_h2_kwargs(self):
         c = HTTPConnection(
             'test', 443, secure=False, window_manager=True, enable_push=True,
             ssl_context=True, proxy_host=False, proxy_port=False,
-            proxy_headers=False, other_kwarg=True
+            proxy_headers=False, other_kwarg=True, timeout=(10, 30)
         )
 
         assert c._h2_kwargs == {
@@ -39,6 +40,7 @@ class TestHTTPConnection(object):
             'proxy_port': False,
             'proxy_headers': False,
             'other_kwarg': True,
+            'timeout': (10, 30),
         }
 
     def test_tls_upgrade(self, monkeypatch):

--- a/test/test_http11.py
+++ b/test/test_http11.py
@@ -110,6 +110,18 @@ class TestHTTP11Connection(object):
         assert c.proxy_host == 'ffff:aaaa::1'
         assert c.proxy_port == 8443
 
+    def test_initialization_timeout(self):
+        c = HTTP11Connection('httpbin.org', timeout=30)
+
+        assert c._connect_timeout == 30
+        assert c._read_timeout == 30
+
+    def test_initialization_tuple_timeout(self):
+        c = HTTP11Connection('httpbin.org', timeout=(5, 60))
+
+        assert c._connect_timeout == 5
+        assert c._read_timeout == 60
+
     def test_basic_request(self):
         c = HTTP11Connection('httpbin.org')
         c._sock = sock = DummySocket()

--- a/test/test_http11.py
+++ b/test/test_http11.py
@@ -113,14 +113,12 @@ class TestHTTP11Connection(object):
     def test_initialization_timeout(self):
         c = HTTP11Connection('httpbin.org', timeout=30)
 
-        assert c._connect_timeout == 30
-        assert c._read_timeout == 30
+        assert c._timeout == 30
 
     def test_initialization_tuple_timeout(self):
         c = HTTP11Connection('httpbin.org', timeout=(5, 60))
 
-        assert c._connect_timeout == 5
-        assert c._read_timeout == 60
+        assert c._timeout == (5, 60)
 
     def test_basic_request(self):
         c = HTTP11Connection('httpbin.org')

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -98,6 +98,18 @@ class TestHyperConnection(object):
         c = HTTP20Connection('www.google.com')
         assert c.version is HTTPVersion.http20
 
+    def test_connection_timeout(self):
+        c = HTTP20Connection('httpbin.org', timeout=30)
+
+        assert c._connect_timeout == 30
+        assert c._read_timeout == 30
+
+    def test_connection_tuple_timeout(self):
+        c = HTTP20Connection('httpbin.org', timeout=(5, 60))
+
+        assert c._connect_timeout == 5
+        assert c._read_timeout == 60
+
     def test_ping(self, frame_buffer):
         def data_callback(chunk, **kwargs):
             frame_buffer.add_data(chunk)

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -101,14 +101,12 @@ class TestHyperConnection(object):
     def test_connection_timeout(self):
         c = HTTP20Connection('httpbin.org', timeout=30)
 
-        assert c._connect_timeout == 30
-        assert c._read_timeout == 30
+        assert c._timeout == 30
 
     def test_connection_tuple_timeout(self):
         c = HTTP20Connection('httpbin.org', timeout=(5, 60))
 
-        assert c._connect_timeout == 5
-        assert c._read_timeout == 60
+        assert c._timeout == (5, 60)
 
     def test_ping(self, frame_buffer):
         def data_callback(chunk, **kwargs):

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1236,20 +1236,14 @@ class TestHyperIntegration(SocketLevelTest):
 
         def socket_handler(listener):
             time.sleep(1)
-            sock = listener.accept()[0]
-            sock.close()
 
         self._start_server(socket_handler)
         conn = self.get_connection()
-        try:
-            conn.connect()
-        except (SocketTimeout, ssl.SSLError):
+
+        with pytest.raises((SocketTimeout, ssl.SSLError)):
             # Py2 raises this as a BaseSSLError,
             # Py3 raises it as socket timeout.
-            # assert 'timed out' in e.message
-            pass
-        else:
-            assert False
+            conn.connect()
 
         self.tear_down()
 
@@ -1279,15 +1273,10 @@ class TestHyperIntegration(SocketLevelTest):
         conn.request('GET', '/')
         req_event.set()
 
-        try:
-            conn.get_response()
-        except (SocketTimeout, ssl.SSLError):
+        with pytest.raises((SocketTimeout, ssl.SSLError)):
             # Py2 raises this as a BaseSSLError,
             # Py3 raises it as socket timeout.
-            # assert 'timed out' in e.message
-            pass
-        else:
-            assert False
+            conn.get_response()
 
         self.tear_down()
 
@@ -1321,7 +1310,7 @@ class TestHyperIntegration(SocketLevelTest):
         except (SocketTimeout, ssl.SSLError):
             # Py2 raises this as a BaseSSLError,
             # Py3 raises it as socket timeout.
-            assert False
+            pytest.fail()
 
         send_event.wait(5)
 

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1244,10 +1244,11 @@ class TestHyperIntegration(SocketLevelTest):
         try:
             conn.connect()
             assert False
-        except (SocketTimeout, ssl.SSLError) as e:
+        except (SocketTimeout, ssl.SSLError):
             # Py2 raises this as a BaseSSLError,
             # Py3 raises it as socket timeout.
-            assert 'timed out' in e.message
+            # assert 'timed out' in e.message
+            pass
 
         self.tear_down()
 
@@ -1290,10 +1291,11 @@ class TestHyperIntegration(SocketLevelTest):
         try:
             conn.get_response()
             assert False
-        except (SocketTimeout, ssl.SSLError) as e:
+        except (SocketTimeout, ssl.SSLError):
             # Py2 raises this as a BaseSSLError,
             # Py3 raises it as socket timeout.
-            assert 'timed out' in e.message
+            # assert 'timed out' in e.message
+            pass
 
         # Awesome, we're done now.
         recv_event.set()

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1290,7 +1290,7 @@ class TestRequestsAdapter(SocketLevelTest):
 
         s = requests.Session()
         s.mount('https://%s' % self.host, HTTP20Adapter())
-        r = s.get('https://%s:%s/some/path' % (self.host, self.port))
+        r = s.get('https://%s:%s/some/path' % (self.host, self.port), timeout=(10, 30))
 
         # Assert about the received values.
         assert r.status_code == 200

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -13,6 +13,7 @@ import time
 import hyper
 import hyper.http11.connection
 import pytest
+from socket import timeout as SocketTimeout
 from contextlib import contextmanager
 from mock import patch
 from concurrent.futures import ThreadPoolExecutor, TimeoutError
@@ -1243,7 +1244,9 @@ class TestHyperIntegration(SocketLevelTest):
         try:
             conn.connect()
             assert False
-        except ssl.SSLError as e:
+        except (SocketTimeout, ssl.SSLError) as e:
+            # Py2 raises this as a BaseSSLError,
+            # Py3 raises it as socket timeout.
             assert 'timed out' in e.message
 
         self.tear_down()
@@ -1287,7 +1290,9 @@ class TestHyperIntegration(SocketLevelTest):
         try:
             conn.get_response()
             assert False
-        except ssl.SSLError as e:
+        except (SocketTimeout, ssl.SSLError) as e:
+            # Py2 raises this as a BaseSSLError,
+            # Py3 raises it as socket timeout.
             assert 'timed out' in e.message
 
         # Awesome, we're done now.
@@ -1321,7 +1326,9 @@ class TestHyperIntegration(SocketLevelTest):
         conn = self.get_connection()
         try:
             conn.connect()
-        except ssl.SSLError:
+        except (SocketTimeout, ssl.SSLError):
+            # Py2 raises this as a BaseSSLError,
+            # Py3 raises it as socket timeout.
             assert False
 
         send_event.wait(5)


### PR DESCRIPTION
[+] Add connection/read timeout for requests adapter, we can use like this:

```
import requests
from hyper.contrib import HTTP20Adapter
s = requests.Session()
s.mount('https://http2bin.org', HTTP20Adapter())
r = s.get('https://http2bin.org/get', timeout=30)
print(r.status_code)
```
