### PR TITLE
HTTP20Adapter.close tests (supersedes #307)

### DIFF
--- a/hyper/contrib.py
+++ b/hyper/contrib.py
@@ -196,3 +196,7 @@ class HTTP20Adapter(HTTPAdapter):
         orig.msg = FakeOriginalResponse(resp.headers.iter_raw())
 
         return response
+
+    def close(self):
+        for connection in self.connections.values():
+            connection._conn.close()

--- a/hyper/contrib.py
+++ b/hyper/contrib.py
@@ -199,4 +199,5 @@ class HTTP20Adapter(HTTPAdapter):
 
     def close(self):
         for connection in self.connections.values():
-            connection._conn.close()
+            connection.close()
+        self.connections.clear()

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -27,6 +27,7 @@ import pytest
 import socket
 import zlib
 from io import BytesIO
+import requests
 
 TEST_DIR = os.path.abspath(os.path.dirname(__file__))
 TEST_CERTS_DIR = os.path.join(TEST_DIR, 'certs')
@@ -1208,6 +1209,22 @@ class TestHTTP20Adapter(object):
             verify=SERVER_CERT_FILE)
         assert conn._conn.ssl_context.check_hostname
         assert conn._conn.ssl_context.verify_mode == ssl.CERT_REQUIRED
+
+    def test_adapter_close(self):
+        """
+        Tests HTTP20Adapter properly closes connections
+        """
+        s = requests.Session()
+        s.mount('https://', HTTP20Adapter())
+        s.close()
+
+    def test_adapter_close_context_manager(self):
+        """
+        Tests HTTP20Adapter properly closes connections via context manager
+        """
+        with requests.Session() as s:
+            a = HTTP20Adapter()
+            s.mount('https://', a)
 
 
 class TestUtilities(object):

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -27,7 +27,6 @@ import pytest
 import socket
 import zlib
 from io import BytesIO
-import requests
 
 TEST_DIR = os.path.abspath(os.path.dirname(__file__))
 TEST_CERTS_DIR = os.path.join(TEST_DIR, 'certs')
@@ -1209,22 +1208,6 @@ class TestHTTP20Adapter(object):
             verify=SERVER_CERT_FILE)
         assert conn._conn.ssl_context.check_hostname
         assert conn._conn.ssl_context.verify_mode == ssl.CERT_REQUIRED
-
-    def test_adapter_close(self):
-        """
-        Tests HTTP20Adapter properly closes connections
-        """
-        s = requests.Session()
-        s.mount('https://', HTTP20Adapter())
-        s.close()
-
-    def test_adapter_close_context_manager(self):
-        """
-        Tests HTTP20Adapter properly closes connections via context manager
-        """
-        with requests.Session() as s:
-            a = HTTP20Adapter()
-            s.mount('https://', a)
 
 
 class TestUtilities(object):

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1747,14 +1747,17 @@ class TestRequestsAdapter(SocketLevelTest):
         s.mount('http://', a)
         r = s.get('http://%s:%s' % (self.host, self.port))
         connections_before_close = list(a.connections.values())
+
+        # ensure that we have at least 1 connection
+        assert connections_before_close
+
         s.close()
 
         # check that connections cache is empty
         assert not a.connections
 
         # check that all connections are actually closed
-        assert (connections_before_close and
-                all(conn._sock is None for conn in connections_before_close))
+        assert all(conn._sock is None for conn in connections_before_close)
 
         assert r.status_code == 201
         assert len(r.headers) == 3
@@ -1796,12 +1799,14 @@ class TestRequestsAdapter(SocketLevelTest):
             r = s.get('http://%s:%s' % (self.host, self.port))
             connections_before_close = list(a.connections.values())
 
+            # ensure that we have at least 1 connection
+            assert connections_before_close
+
         # check that connections cache is empty
         assert not a.connections
 
         # check that all connections are actually closed
-        assert (connections_before_close and
-                all(conn._sock is None for conn in connections_before_close))
+        assert all(conn._sock is None for conn in connections_before_close)
 
         assert r.status_code == 201
         assert len(r.headers) == 3

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1717,3 +1717,80 @@ class TestRequestsAdapter(SocketLevelTest):
                   timeout=(10, 0.5))
 
         self.tear_down()
+
+    def test_adapter_close(self):
+        self.set_up(secure=False)
+
+        def socket_handler(listener):
+            sock = listener.accept()[0]
+
+            # We should get the initial request.
+            data = b''
+            while not data.endswith(b'\r\n\r\n'):
+                data += sock.recv(65535)
+
+            # We need to send back a response.
+            resp = (
+                b'HTTP/1.1 201 No Content\r\n'
+                b'Server: socket-level-server\r\n'
+                b'Content-Length: 0\r\n'
+                b'Connection: close\r\n'
+                b'\r\n'
+            )
+            sock.send(resp)
+            sock.close()
+
+        self._start_server(socket_handler)
+
+        s = requests.Session()
+        s.mount('http://', HTTP20Adapter())
+        r = s.get('http://%s:%s' % (self.host, self.port))
+        s.close()
+
+        assert r.status_code == 201
+        assert len(r.headers) == 3
+        assert r.headers['server'] == 'socket-level-server'
+        assert r.headers['content-length'] == '0'
+        assert r.headers['connection'] == 'close'
+
+        assert r.content == b''
+
+        self.tear_down()
+
+    def test_adapter_close_context_manager(self):
+        self.set_up(secure=False)
+
+        def socket_handler(listener):
+            sock = listener.accept()[0]
+
+            # We should get the initial request.
+            data = b''
+            while not data.endswith(b'\r\n\r\n'):
+                data += sock.recv(65535)
+
+            # We need to send back a response.
+            resp = (
+                b'HTTP/1.1 201 No Content\r\n'
+                b'Server: socket-level-server\r\n'
+                b'Content-Length: 0\r\n'
+                b'Connection: close\r\n'
+                b'\r\n'
+            )
+            sock.send(resp)
+            sock.close()
+
+        self._start_server(socket_handler)
+
+        with requests.Session() as s:
+            s.mount('http://', HTTP20Adapter())
+            r = s.get('http://%s:%s' % (self.host, self.port))
+
+        assert r.status_code == 201
+        assert len(r.headers) == 3
+        assert r.headers['server'] == 'socket-level-server'
+        assert r.headers['content-length'] == '0'
+        assert r.headers['connection'] == 'close'
+
+        assert r.content == b''
+
+        self.tear_down()


### PR DESCRIPTION
Add `close()` method implementation to the requests adapter and integration tests for it.

Supersedes #307
Related issue: #306