### PR TITLE
Fix connection upgrade to work for both python2 and python3

### DIFF
--- a/hyper/http20/connection.py
+++ b/hyper/http20/connection.py
@@ -403,7 +403,7 @@ class HTTP20Connection(object):
         with self._conn as conn:
             conn.initiate_upgrade_connection()
             conn.update_settings(
-                {h2.settings.ENABLE_PUSH: int(self._enable_push)}
+                {h2.settings.SettingsFrame.ENABLE_PUSH: int(self._enable_push)}
             )
         self._send_outstanding_data()
 


### PR DESCRIPTION
I had an issue with this line of code not working in a python3 package, because the code in the h2 package differs between these 2 versions of python