### PR TITLE
Fix http11 head response

### DIFF
--- a/hyper/http11/response.py
+++ b/hyper/http11/response.py
@@ -53,10 +53,13 @@ class HTTP11Response(object):
             self._expect_close = True
 
         # The expected length of the body.
-        try:
-            self._length = int(self.headers[b'content-length'][0])
-        except KeyError:
-            self._length = None
+        if request_method.upper() != b'HEAD':
+            try:
+                self._length = int(self.headers[b'content-length'][0])
+            except KeyError:
+                self._length = None
+        else:
+            self._length = 0
 
         # Whether we expect a chunked response.
         self._chunked = (

--- a/hyper/http11/response.py
+++ b/hyper/http11/response.py
@@ -63,7 +63,7 @@ class HTTP11Response(object):
 
         # Whether we expect a chunked response.
         self._chunked = (
-                b'chunked' in self.headers.get(b'transfer-encoding', [])
+            b'chunked' in self.headers.get(b'transfer-encoding', [])
         )
 
         # When content-length is absent and response is not chunked,

--- a/hyper/http11/response.py
+++ b/hyper/http11/response.py
@@ -53,7 +53,7 @@ class HTTP11Response(object):
             self._expect_close = True
 
         # The expected length of the body.
-        if request_method.upper() != b'HEAD':
+        if request_method != b'HEAD':
             try:
                 self._length = int(self.headers[b'content-length'][0])
             except KeyError:

--- a/hyper/http11/response.py
+++ b/hyper/http11/response.py
@@ -63,7 +63,7 @@ class HTTP11Response(object):
 
         # Whether we expect a chunked response.
         self._chunked = (
-            b'chunked' in self.headers.get(b'transfer-encoding', [])
+                b'chunked' in self.headers.get(b'transfer-encoding', [])
         )
 
         # When content-length is absent and response is not chunked,

--- a/test/test_http11.py
+++ b/test/test_http11.py
@@ -941,6 +941,18 @@ class TestHTTP11Response(object):
         r = HTTP11Response(200, 'OK', headers, d)
         assert r.version is HTTPVersion.http11
 
+    def test_response_body_length(self):
+        methods = [b'HEAD', b'GET']
+        headers = {b'content-length': [b'15']}
+        d = DummySocket()
+        for method in methods:
+            d.queue = []
+            r = HTTP11Response(200, 'OK', headers, d, request_method=method)
+            if method == b'HEAD':
+                assert r._length == 0
+            else:
+                assert r._length == int(r.headers[b'content-length'][0])
+
 
 class DummySocket(object):
     def __init__(self):

--- a/test_release.py
+++ b/test_release.py
@@ -168,3 +168,27 @@ class TestHyperActuallyWorks(object):
         assert response.status == 200
         assert response.read()
         assert response.version == HTTPVersion.http20
+
+    def test_http11_response_body_length(self):
+        """
+        This test function uses check the expected length of the HTTP/1.1-response-body.
+        """
+        c = HTTP11Connection('httpbin.org:443')
+
+        # Make some HTTP/1.1 requests.
+        methods = ['GET', 'HEAD']
+        for method in methods:
+            c.request(method, '/')
+            resp = c.get_response()
+
+            # Check the expected length of the body.
+            if method == 'HEAD':
+                assert resp._length == 0
+                assert resp.read() == b''
+            else:
+                try:
+                    content_length = int(resp.headers[b'Content-Length'][0])
+                except KeyError:
+                    continue
+                assert resp._length == content_length
+                assert resp.read()


### PR DESCRIPTION
- Dealing with the problem of reading an empty body from HTTP / 1.1 HEAD response.
- Add test function related to the problem.