### PR TITLE
Fix crash on getting unsupported content-encoding

### DIFF
--- a/hyper/http20/response.py
+++ b/hyper/http20/response.py
@@ -79,8 +79,9 @@ class HTTP20Response(object):
         # Stack Overflow answer for more:
         # http://stackoverflow.com/a/2695466/1401686
         for c in self.headers.get(b'content-encoding', []):
-            self._decompressobj = decompressors.get(c)()
-            break
+            if c in decompressors:
+                self._decompressobj = decompressors.get(c)()
+                break
 
     @property
     def trailers(self):

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -1110,6 +1110,15 @@ class TestResponse(object):
 
         assert resp.read() == b'this is test data'
 
+    def test_response_ignored_unsupported_compression(self):
+        headers = HTTPHeaderMap(
+            [(':status', '200'), ('content-encoding', 'invalid')]
+        )
+        body = b'this is test data'
+        resp = HTTP20Response(headers, DummyStream(body))
+
+        assert resp.read() == b'this is test data'
+
     def test_response_calls_stream_close(self):
         headers = HTTPHeaderMap([(':status', '200')])
         stream = DummyStream('')


### PR DESCRIPTION
Hyper currently crashes on seeing an unsupported `content-encoding` (eg, `br`).

This patch makes hyper silently ignore this and not attempt decompression.