### PR TITLE
Don't split the authorization header

### DIFF
--- a/hyper/common/headers.py
+++ b/hyper/common/headers.py
@@ -242,7 +242,7 @@ def canonical_form(k, v):
     canonical form. This means that the header is split on commas unless for
     any reason it's a super-special snowflake (I'm looking at you Set-Cookie).
     """
-    SPECIAL_SNOWFLAKES = set([b'set-cookie', b'set-cookie2'])
+    SPECIAL_SNOWFLAKES = set([b'set-cookie', b'set-cookie2', b'authorization'])
 
     k = k.lower()
 

--- a/test/test_headers.py
+++ b/test/test_headers.py
@@ -125,6 +125,12 @@ class TestHTTPHeaderMap(object):
         assert h['set-cookie'] == [b'v1, v2']
         assert h.get(b'set-cookie') == [b'v1, v2']
 
+    def test_doesnt_split_authorization(self):
+        h = HTTPHeaderMap()
+        h['Authorization'] = 'Do, Not, Split'
+        assert h['authorization'] == [b'Do, Not, Split']
+        assert h.get(b'authorization') == [b'Do, Not, Split']
+
     def test_equality(self):
         h1 = HTTPHeaderMap()
         h1['k1'] = 'v1, v2'


### PR DESCRIPTION
Some authorization schemes have commas in the header and splitting this header will break authentication. This adds the authorization header to the list of headers that should not be split.