### PR TITLE
Use iter_raw when making headers h2-safe to preserve original headers

### DIFF
--- a/hyper/http20/util.py
+++ b/hyper/http20/util.py
@@ -56,5 +56,8 @@ def h2_safe_headers(headers):
         for i in v.split(b',')
     }
     stripped.add(b'connection')
-
-    return [header for header in headers if header[0] not in stripped]
+    if hasattr(headers, 'iter_raw'):
+        iter_raw = headers.iter_raw()
+    else:
+        iter_raw = headers
+    return [header for header in iter_raw if header[0] not in stripped]

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -1355,6 +1355,12 @@ class TestUtilities(object):
 
         assert h2_safe_headers(headers) == stripped
 
+    def test_stripping_headers_leaves_commas_and_space_intact(self):
+        headers = HTTPHeaderMap(**{'one': 'two, three,  four'})
+        stripped = [(b'one', b'two, three,  four')]
+
+        assert h2_safe_headers(headers) == stripped
+
     def test_goaway_frame_PROTOCOL_ERROR(self):
         f = GoAwayFrame(0)
         # Set error code to PROTOCOL_ERROR


### PR DESCRIPTION
Fixes #389 