### PR TITLE
Added the possibility of passing an external socket to HTTP20Connection

### DIFF
--- a/hyper/http20/connection.py
+++ b/hyper/http20/connection.py
@@ -102,7 +102,7 @@ class HTTP20Connection(object):
     def __init__(self, host, port=None, secure=None, window_manager=None,
                  enable_push=False, ssl_context=None, proxy_host=None,
                  proxy_port=None, force_proto=None, proxy_headers=None,
-                 timeout=None, **kwargs):
+                 timeout=None, external_socket=None, **kwargs):
         """
         Creates an HTTP/2 connection to a specific server.
         """
@@ -153,6 +153,8 @@ class HTTP20Connection(object):
 
         # timeout
         self._timeout = timeout
+
+        self._sock = external_socket
 
         return
 


### PR DESCRIPTION
ONVIF  defines  the  Uplink  service  based  on  HTTP/2  and  connection
reversal,  in order  to have  cameras  connect to  cloud services  while
having  NAT between  themselves  and the  remote  service (For  details,
https://www.onvif.org/specs/srv/uplink/ONVIF-Uplink-Spec.pdf)

With this patch, it is possible on  the cloud side to accept an incoming
connection  from a  listining  socket  and to  pass  the  new socket  to
HTTP20Connection,  so  that the  cloud  software  can use  the  reverted
connection and turn itself into a client.

Example code for implementing it:

```
import socket, ssl, time

from hyper import HTTP20Connection
from hyper.common.bufsocket import BufferedSocket

context = ssl.SSLContext (ssl.PROTOCOL_TLSv1_2)
context.load_cert_chain ("server.cert", "server.key")

bindsocket = socket.socket ()
bindsocket.bind(('', 8081))
bindsocket.listen(5)

with context.wrap_socket (bindsocket, server_side=True) as ssock:
    while True:
        newsocket, fromaddr = ssock.accept()

        req = newsocket.read ()

        if b'Connection: Upgrade' in req and b'Upgrade: h2c-reverse':
            newsocket.write (b'HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: h2c-reverse\r\n\r\n')
            newsocket.write (b'PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n')

            c = HTTP20Connection ('unused.org', external_socket = BufferedSocket (newsocket))

            c.request('POST', '/onvif/device_service', headers = { 'Content-Type': 'application/soap+xml; charset=utf-8'}, body=b'<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:tds="http://www.onvif.org/ver10/device/wsdl" xmlns:tt="http://www.onvif.org/ver10/schema"><soap:Body><tds:GetDeviceInformation /></soap:Body></soap:Envelope>'))
            resp = c.get_response ()
            print (resp.read ())
```