### PR TITLE
Fix for python 3.7-3.9

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -135,8 +135,8 @@ Using ``hyper`` with requests is super simple::
     >>> import requests
     >>> from hyper.contrib import HTTP20Adapter
     >>> s = requests.Session()
-    >>> s.mount('https://http2bin.org', HTTP20Adapter())
-    >>> r = s.get('https://http2bin.org/get')
+    >>> s.mount('https://', HTTP20Adapter())
+    >>> r = s.get('https://httpbin.org/get')
     >>> print(r.status_code)
     200
 

--- a/hyper/common/headers.py
+++ b/hyper/common/headers.py
@@ -5,12 +5,16 @@ hyper/common/headers
 
 Contains hyper's structures for storing and working with HTTP headers.
 """
-import collections
+try:
+    from collections.abc import MutableMapping
+except ImportError:  # pragma: no cover
+    # Python 2.7 compatibility
+    from collections import MutableMapping
 
 from hyper.common.util import to_bytestring, to_bytestring_tuple
 
 
-class HTTPHeaderMap(collections.MutableMapping):
+class HTTPHeaderMap(MutableMapping):
     """
     A structure that contains HTTP headers.
 

--- a/hyper/http11/connection.py
+++ b/hyper/http11/connection.py
@@ -10,9 +10,12 @@ import os
 import socket
 import base64
 
-from collections import Iterable, Mapping
+try:
+    from collections.abc import Iterable, Mapping
+except ImportError:  # pragma: no cover
+    # Python 2.7 compatibility
+    from collections import Iterable, Mapping
 
-import collections
 from hyperframe.frame import SettingsFrame
 
 from .response import HTTP11Response
@@ -390,7 +393,7 @@ class HTTP11Connection(object):
                 return
 
             # Iterables that set a specific content length.
-            elif isinstance(body, collections.Iterable):
+            elif isinstance(body, Iterable):
                 for item in body:
                     try:
                         self._sock.send(item)

--- a/hyper/http20/connection.py
+++ b/hyper/http20/connection.py
@@ -403,7 +403,7 @@ class HTTP20Connection(object):
         with self._conn as conn:
             conn.initiate_upgrade_connection()
             conn.update_settings(
-                {h2.settings.ENABLE_PUSH: int(self._enable_push)}
+                {h2.settings.SettingCodes.ENABLE_PUSH: int(self._enable_push)}
             )
         self._send_outstanding_data()
 
@@ -424,7 +424,7 @@ class HTTP20Connection(object):
         with self._conn as conn:
             conn.initiate_connection()
             conn.update_settings(
-                {h2.settings.ENABLE_PUSH: int(self._enable_push)}
+                {h2.settings.SettingCodes.ENABLE_PUSH: int(self._enable_push)}
             )
         self._send_outstanding_data()
 

--- a/hyper/tls.py
+++ b/hyper/tls.py
@@ -122,8 +122,8 @@ def init_context(cert_path=None, cert=None, cert_password=None):
 
     if cert is not None:
         try:
-            basestring
-        except NameError:
+            from builtins import basestring
+        except ImportError:
             basestring = (str, bytes)
         if not isinstance(cert, basestring):
             context.load_cert_chain(cert[0], cert[1], cert_password)

--- a/test/test_hyper.py
+++ b/test/test_hyper.py
@@ -766,7 +766,8 @@ class TestHyperConnection(object):
         # the default max frame size (16,384 bytes). That will, on the third
         # frame, trigger the processing to increment the flow control window,
         # which should then not happen.
-        f = SettingsFrame(0, settings={h2.settings.INITIAL_WINDOW_SIZE: 100})
+        f = SettingsFrame(0, settings={
+            h2.settings.SettingCodes.INITIAL_WINDOW_SIZE: 100})
 
         c = HTTP20Connection('www.google.com')
         c._sock = DummySocket()

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
 pytest>=3.0
-pytest-xdist
+pytest-xdist<=1.27.0
 pytest-cov
 requests
 mock


### PR DESCRIPTION
This import now works on my python 3.9:
from hyper.contrib import HTTP20Adapter

I also needed to:
pip install git+https://github.com/python-hyper/hyper-h2.git -U
pip install git+https://github.com/python-hyper/hyperframe.git -U

which told me that:
ERROR: hyper 0.8.0.dev0 has requirement h2!=2.5.0,<3.0,>=2.4, but you'll have h2 3.2.0 which is incompatible.
ERROR: hyper 0.8.0.dev0 has requirement hyperframe<4.0,>=3.2, but you'll have hyperframe 5.2.0 which is incompatible.

But it works now (at least for me):
```
Python 3.9.0a3+ (heads/master:1b55b65638, Feb 17 2020, 12:08:41) 
[GCC 7.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import requests
>>> import logging;logging.basicConfig();logging.getLogger().setLevel(logging.DEBUG)
>>> import http.client;http.client.HTTPConnection.debuglevel = 1
>>> s = requests.Session()
>>> r = s.get('https://httpbin.org/get')
...
reply: 'HTTP/1.1 200 OK\r\n'
...
>>> from hyper.contrib import HTTP20Adapter
>>> s.mount('https://', HTTP20Adapter())
>>> r = s.get('https://httpbin.org/get')
DEBUG:hyper.http11.connection:Selected protocol: h2
...
```
Maybe adding logging will help people in the quickstart to see more than a status code, too.